### PR TITLE
Update options.md

### DIFF
--- a/IdentityServer/v5/docs/content/reference/options.md
+++ b/IdentityServer/v5/docs/content/reference/options.md
@@ -36,16 +36,14 @@ Top-level settings.
 * ***EmitScopesAsSpaceDelimitedStringInJwt***
   
     Specifies whether scopes in JWTs are emitted as array or string
+    
+    Historically scopes values were emitted as an array in JWT access tokens.
+    The newer JWT for OAuth profile specifies a space delimited string instead.
+    The behavior can be toggled here (defaults to *false* for backwards compatibility).
 
 * ***EmitStaticAudienceClaim***
   
     Emits a static *aud* claim in all access tokens with the format *issuer/resources*. Defaults to *false*.
-
-* ***EmitScopesAsSpaceDelimitedStringsInJwt***
-
-    Historically scopes values were emitted as an array in JWT access tokens.
-    The newer JWT for OAuth profile specifies a space delimited string instead.
-    The behavior can be toggled here (defaults to *false* for backwards compatibility).
 
 ## Key management
 Controls the automatic key management settings.


### PR DESCRIPTION
It appears that `EmitScopesAsSpaceDelimitedStringInJwt` was listed twice, the second time with an extra "s". I Consolidated the two into into a single entry.