### PR TITLE
Added clarification note for custom sinks

### DIFF
--- a/IdentityServer/v5/docs/content/diagnostics/events.md
+++ b/IdentityServer/v5/docs/content/diagnostics/events.md
@@ -45,7 +45,7 @@ Our default event sink will simply serialize the event class to JSON and forward
 If you want to connect to a custom event store, implement the *IEventSink* interface and register it with DI.  
 
 {{% notice info %}}
-The `SeqEventSink` example below should be registered as a singleton, or the sink should implement `IDisposable` and dispose of the `Logger` object in the Dispose method.  
+The *SeqEventSink* example below should be registered as a singleton, or the sink should implement *IDisposable* and dispose of the *Logger* object in the Dispose method.  
 {{% /notice %}}
 
 The following example uses [Seq](https://getseq.net) to emit events:

--- a/IdentityServer/v5/docs/content/diagnostics/events.md
+++ b/IdentityServer/v5/docs/content/diagnostics/events.md
@@ -42,7 +42,11 @@ public async Task<IActionResult> Login(LoginInputModel model)
 
 ### Custom sinks
 Our default event sink will simply serialize the event class to JSON and forward it to the ASP.NET Core logging system.
-If you want to connect to a custom event store, implement the *IEventSink* interface and register it with DI.
+If you want to connect to a custom event store, implement the *IEventSink* interface and register it with DI.  
+
+{{% notice info %}}
+The `SeqEventSink` example below should be registered as a singleton, or the sink should implement `IDisposable` and dispose of the `Logger` object in the Dispose method.  
+{{% /notice %}}
 
 The following example uses [Seq](https://getseq.net) to emit events:
 


### PR DESCRIPTION
In a Kubernetes environment where I had set specific memory limits, using a "scoped" service much like the one above, it was leaking the `Logger` object with each http request to the IdentityServer.  Eventually this would result in my pod getting "OOMKilled" with an error code of 137 - memory limit exceeded.  By changing the service registration to a singleton the memory is staying steady.