### PR TITLE
Nuget package dependency error

### DIFF
--- a/IdentityServer/v5/docs/content/quickstarts/2_interactive.md
+++ b/IdentityServer/v5/docs/content/quickstarts/2_interactive.md
@@ -59,6 +59,7 @@ We recommend using the self-host option over IIS Express. The rest of the docs a
 To add support for OpenID Connect authentication to the MVC application, you first need to add the nuget package containing the OpenID Connect handler to your project, e.g.::
 
     dotnet add package Microsoft.AspNetCore.Authentication.OpenIdConnect
+    dotnet add package System.IdentityModel.Tokens.Jwt
 
 ..then add the following to *ConfigureServices* in *Startup*:
 


### PR DESCRIPTION
Nuget package "Microsoft.AspNetCore.Authentication.OpenIdConnect" isn't include "System.IdentityModel.Tokens.Jwt" namespace, it was isolated to a new Nuget package.