### PR TITLE
Missing comma in client

### DIFF
--- a/IdentityServer/v5/docs/content/tokens/authentication/mtls.md
+++ b/IdentityServer/v5/docs/content/tokens/authentication/mtls.md
@@ -31,7 +31,7 @@ new Client
 {
     ClientId = "mtls.client",
     AllowedGrantTypes = GrantTypes.ClientCredentials,
-    AllowedScopes = { "api1" }
+    AllowedScopes = { "api1" },
 
     ClientSecrets = 
     {


### PR DESCRIPTION
A missing comma between AllowedScopes and ClientSecrets.