### PR TITLE
Update 1_client_credentials.md

### DIFF
--- a/IdentityServer/v6/docs/content/quickstarts/1_client_credentials.md
+++ b/IdentityServer/v6/docs/content/quickstarts/1_client_credentials.md
@@ -463,23 +463,10 @@ You can now enforce this policy at various levels, e.g.:
 * for all API endpoints
 * for specific controllers/actions
 
-Typically you setup the policy for all API endpoints in the routing system.
-You'll have to add a call to app.UseRouting() *before* the call the app.UseEndpoints(),
-and *remove* the call to app.MapControllers(). Also, if there are calls to
-*both* app.UseRouting() and app.UseEndpoints(...), the call to app.UseAuthorization() must go between them:
+Typically you set the policy for all controllers where they are mapped in *Api\Program.cs*:
 
 ```cs
-app.UseRouting();
-...
-app.UseAuthorization();
-...
-app.UseEndpoints(endpoints =>
-{
-    endpoints.MapControllers()
-        .RequireAuthorization("ApiScope");
-});
-
-//app.MapControllers();
+app.MapControllers().RequireAuthorization("ApiScope");
 ```
 
 ## Further experiments

--- a/IdentityServer/v6/docs/content/quickstarts/1_client_credentials.md
+++ b/IdentityServer/v6/docs/content/quickstarts/1_client_credentials.md
@@ -168,7 +168,7 @@ minimal ConfigureServices method that is needed:
 ```csharp
 public static WebApplication ConfigureServices(this WebApplicationBuilder builder)
 {
-    var builder = services.AddIdentityServer()
+    builder.Services.AddIdentityServer()
         .AddInMemoryApiScopes(Config.ApiScopes)
         .AddInMemoryClients(Config.Clients);
 
@@ -463,14 +463,23 @@ You can now enforce this policy at various levels, e.g.:
 * for all API endpoints
 * for specific controllers/actions
 
-Typically you setup the policy for all API endpoints in the routing system:
+Typically you setup the policy for all API endpoints in the routing system.
+You'll have to add a call to app.UseRouting() *before* the call the app.UseEndpoints(),
+and *remove* the call to app.MapControllers(). Also, if there are calls to
+*both* app.UseRouting() and app.UseEndpoints(...), the call to app.UseAuthorization() must go between them:
 
 ```cs
+app.UseRouting();
+...
+app.UseAuthorization();
+...
 app.UseEndpoints(endpoints =>
 {
     endpoints.MapControllers()
         .RequireAuthorization("ApiScope");
 });
+
+//app.MapControllers();
 ```
 
 ## Further experiments


### PR DESCRIPTION
Fixes code example error that was using "var builder = services..." instead of "builder.Services...".
Expands note and code example of additional requirements when using "app.UseEndpoints(...)".
Comments out call to app.MapControllers() and notes it in description.