### PR TITLE
Correct typo in quickstart 2

### DIFF
--- a/IdentityServer/v6/docs/content/quickstarts/2_interactive.md
+++ b/IdentityServer/v6/docs/content/quickstarts/2_interactive.md
@@ -283,7 +283,7 @@ basis.
 
 ### Display the Auth Cookie
 
-Modify *geWebClient/Pas/Index.cshtml* to display the claims of the user and the
+Modify *WebClient/Pages/Index.cshtml* to display the claims of the user and the
 cookie properties:
 
 ```cs
@@ -305,7 +305,7 @@ cookie properties:
 <h2>Properties</h2>
 
 <dl>
-    @foreach (var prop in (await Context.AuthenticateAsync()).Properties.Items)
+    @foreach (var prop in (await HttpContext.AuthenticateAsync()).Properties.Items)
     {
         <dt>@prop.Key</dt>
         <dd>@prop.Value</dd>


### PR DESCRIPTION
This fixes issue #99. The [corresponding line](https://github.com/DuendeSoftware/Samples/blob/b0e7b46e5fded1252371d9480a36707ae56d2681/IdentityServer/v6/Quickstarts/2_InteractiveAspNetCore/src/WebClient/Pages/Index.cshtml#L19) in the Samples repo is correct.