### PR TITLE
add missing scope in docs for quickstart3

### DIFF
--- a/IdentityServer/v6/docs/content/quickstarts/3_api_access.md
+++ b/IdentityServer/v6/docs/content/quickstarts/3_api_access.md
@@ -86,6 +86,8 @@ builder.Services.AddAuthentication(options =>
 
         options.SaveTokens = true;
 
+        options.Scope.Clear();
+        options.Scope.Add("openid");
         options.Scope.Add("profile");
         options.Scope.Add("api1");
         options.Scope.Add("offline_access");


### PR DESCRIPTION
Without the openid scope, you get this error when running the web client:

> Sorry, there was an error : invalid_scope
> Identity scopes requested, but openid scope is missing