### PR TITLE
Working CallApiModel code.

### DIFF
--- a/IdentityServer/v6/docs/content/quickstarts/3_api_access.md
+++ b/IdentityServer/v6/docs/content/quickstarts/3_api_access.md
@@ -119,7 +119,13 @@ dotnet new page -n CallApi
 
 Update *WebClient\Pages\CallApi.cshtml.cs* as follows:
 ```cs
-public async Task<IActionResult> OnGet()
+public string? Json
+{
+    get => ViewData["Json"] as string;
+    private set => ViewData["Json"] = value;
+}
+
+public async Task OnGet()
 {
     var accessToken = await HttpContext.GetTokenAsync("access_token");
 
@@ -128,10 +134,7 @@ public async Task<IActionResult> OnGet()
     var content = await client.GetStringAsync("https://localhost:6001/identity");
 
     var parsed = JsonDocument.Parse(content);
-    var formatted = JsonSerializer.Serialize(parsed, new JsonSerializerOptions { WriteIndented = true });
-
-    ViewBag.Json = formatted;
-    return View("json");
+    Json = JsonSerializer.Serialize(parsed, new JsonSerializerOptions { WriteIndented = true });
 }
 ```
 


### PR DESCRIPTION
The documented `CallApi.cshtml.cs` code does not seem to compile with .NET Core 6.0. Both `ViewBag` and `View` do not seem to exist.

These changes contain code that works and displays the formatted JSON response from the call to the API.