### PR TITLE
Updates example code for CallApi.cshtml.cs

### DIFF
--- a/IdentityServer/v6/docs/content/quickstarts/3_api_access.md
+++ b/IdentityServer/v6/docs/content/quickstarts/3_api_access.md
@@ -119,19 +119,22 @@ dotnet new page -n CallApi
 
 Update *WebClient\Pages\CallApi.cshtml.cs* as follows:
 ```cs
-public async Task<IActionResult> OnGet()
+public class CallApiModel : PageModel
 {
-    var accessToken = await HttpContext.GetTokenAsync("access_token");
+    public string Json = string.Empty;
 
-    var client = new HttpClient();
-    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-    var content = await client.GetStringAsync("https://localhost:6001/identity");
+    public async Task OnGet()
+    {
+        var accessToken = await HttpContext.GetTokenAsync("access_token");
+        var client = new HttpClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        var content = await client.GetStringAsync("https://localhost:6001/identity");
 
-    var parsed = JsonDocument.Parse(content);
-    var formatted = JsonSerializer.Serialize(parsed, new JsonSerializerOptions { WriteIndented = true });
+        var parsed = JsonDocument.Parse(content);
+        var formatted = JsonSerializer.Serialize(parsed, new JsonSerializerOptions { WriteIndented = true });
 
-    ViewBag.Json = formatted;
-    return View("json");
+        Json = formatted;
+    }
 }
 ```
 


### PR DESCRIPTION
Updates example code for CallApi.cshtml.cs to match the newest template. The Json property was not in the old code, but the .cshtml was (correctly) referencing it, so it wasn't compiling.