### PR TITLE
Fix --trust rendering

### DIFF
--- a/IdentityServer/v6/docs/content/quickstarts/1_client_credentials.md
+++ b/IdentityServer/v6/docs/content/quickstarts/1_client_credentials.md
@@ -350,8 +350,8 @@ if (disco.IsError)
 {{% notice note %}}
 
 If you get an error connecting it may be that you are running *https* and the
-development certificate for *localhost* is not trusted. You can run *dotnet
-dev-certs https --trust* in order to trust the development certificate. This
+development certificate for *localhost* is not trusted. You can run `dotnet
+dev-certs https --trust` in order to trust the development certificate. This
 only needs to be done once. 
 
 {{% /notice %}}


### PR DESCRIPTION
Double dashes are rendered as em dash outside `preformatted text`