### PR TITLE
fix: user display name claim type options sample

### DIFF
--- a/IdentityServer/v6/docs/content/ui/server_side_sessions/_index.md
+++ b/IdentityServer/v6/docs/content/ui/server_side_sessions/_index.md
@@ -65,7 +65,7 @@ For example:
 public void ConfigureServices(IServiceCollection services)
 {
     services.AddIdentityServer(options => {
-        options.Authentication.UserDisplayNameClaimType = "name"; // or "email" perhaps
+        options.ServerSideSessions.UserDisplayNameClaimType = "name"; // or "email" perhaps
     })
         .AddServerSideSessions();
 }


### PR DESCRIPTION
`UserDisplayNameClaimType` is in `ServerSideSessions` not in `Authentication` section.