### PR TITLE
Align Config.cs end result with previous work

### DIFF
--- a/IdentityServer/v6/docs/content/quickstarts/5_aspnetid.md
+++ b/IdentityServer/v6/docs/content/quickstarts/5_aspnetid.md
@@ -139,6 +139,8 @@ public static class Config
 
                 // where to redirect to after logout
                 PostLogoutRedirectUris = { "https://localhost:5002/signout-callback-oidc" },
+    
+                AllowOfflineAccess = true,
 
                 AllowedScopes = new List<string>
                 {


### PR DESCRIPTION
`web` client was previously set up with AllowOfflineAccess set true here:
https://docs.duendesoftware.com/identityserver/v6/quickstarts/3_api_access/#modifying-the-client-configuration

If you're following along in and simply copy from the docs instead of copying the actual file, this will trip you up, with an "invalid_grant" error.