### PR TITLE
Update 1_client_credentials.md with .net 6 changes

### DIFF
--- a/IdentityServer/v6/docs/content/quickstarts/1_client_credentials.md
+++ b/IdentityServer/v6/docs/content/quickstarts/1_client_credentials.md
@@ -444,10 +444,10 @@ token. The protocol ensures that this scope will only be in the token if the
 client requests it and IdentityServer allows the client to have that scope. You
 configured IdentityServer to allow this access by [including it in the
 allowedScopes property](#define-client). Add the following to the
-*ConfigureServices* method in the API's *Startup.cs* file:
+*ConfigureServices* method in the API's *Program.cs* file:
 
 ```cs
-services.AddAuthorization(options =>
+builder.Services.AddAuthorization(options =>
 {
     options.AddPolicy("ApiScope", policy =>
     {


### PR DESCRIPTION
In a code block a reference to the builder was missing and a reference to Startup.cs was accidentally left in when it is now Program.cs