### PR TITLE
Don't try to deploy forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ on:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    env: 
+      AZURE_STATIC_WEB_APPS_API_TOKEN_HAPPY_OCEAN_048B8E60F: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_HAPPY_OCEAN_048B8E60F }}
+    if: (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')) && AZURE_STATIC_WEB_APPS_API_TOKEN_HAPPY_OCEAN_048B8E60F != ''
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
@@ -42,7 +44,9 @@ jobs:
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    env: 
+      AZURE_STATIC_WEB_APPS_API_TOKEN_HAPPY_OCEAN_048B8E60F: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_HAPPY_OCEAN_048B8E60F }}
+    if: (github.event_name == 'pull_request' && github.event.action == 'closed') && AZURE_STATIC_WEB_APPS_API_TOKEN_HAPPY_OCEAN_048B8E60F != ''
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     steps:


### PR DESCRIPTION
Prevent deploys from forks because they don't have api keys and always fail anyway.

This copies the secret into an environment variable because secrets cannot be used in conditionals, as per these docs: https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow.