### PR TITLE
Add missing ampersand to x-www-form-urlencoded data

### DIFF
--- a/IdentityServer/v6/docs/content/tokens/password_grant.md
+++ b/IdentityServer/v6/docs/content/tokens/password_grant.md
@@ -21,8 +21,7 @@ Host: demo.duendesoftware.com
 Content-Type: application/x-www-form-urlencoded
 
 client_id=client&
-client_secret=secret
-
+client_secret=secret&
 grant_type=password&
 username=bob&
 password=password


### PR DESCRIPTION
An ampersand ('&') is missing in the payload for "Requesting a token using Password grant"