### PR TITLE
Fix broken links on specs page

### DIFF
--- a/IdentityServer/v6/docs/content/overview/specs.md
+++ b/IdentityServer/v6/docs/content/overview/specs.md
@@ -13,9 +13,9 @@ Duende IdentityServer implements the following specifications:
 * OpenID Connect RP-Initiated Logout 1.0 ([spec](https://openid.net/specs/openid-connect-rpinitiated-1_0.html))
 * OpenID Connect Session Management 1.0 ([spec](http://openid.net/specs/openid-connect-session-1_0.html))
 * OpenID Connect Front-Channel Logout 1.0 ([spec](https://openid.net/specs/openid-connect-frontchannel-1_0.html))
-* OpenID Connect Back-Channel Logout 1.0 ([spec](https://openid.net/specs/openid-connect-backchannel-1_0.html>))
+* OpenID Connect Back-Channel Logout 1.0 ([spec](https://openid.net/specs/openid-connect-backchannel-1_0.html))
 * Multiple Response Types ([spec](http://openid.net/specs/oauth-v2-multiple-response-types-1_0.html))
-* Form Post Response Mode ([spec](http://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html>))
+* Form Post Response Mode ([spec](http://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html))
 * Enterprise Edition: OpenID Connect Client-Initiated Backchannel Authentication (CIBA) ([spec](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html)).
 
 ### OAuth 2.x


### PR DESCRIPTION
Happened to notice when reading up on the product. Small change, let me know if you want the commit signed-off or such (couldn't find any "contributing" spec).