### PR TITLE
Refresh token rotation advice and options

### DIFF
--- a/IdentityServer/v6/docs/content/bff/session/server_side_sessions.md
+++ b/IdentityServer/v6/docs/content/bff/session/server_side_sessions.md
@@ -42,8 +42,8 @@ Most datastores that you might use with Entity Framework use a schema to define 
 
 Added in v1.2.0.
 
-Abandonded sessions will remain in the store unless something removes the stale entries.
-If you wish to have abandonded sessions cleaned up perodically, then you can configure the *EnableSessionCleanup* and *SessionCleanupInterval* options:
+Abandoned sessions will remain in the store unless something removes the stale entries.
+If you wish to have such sessions cleaned up periodically, then you can configure the *EnableSessionCleanup* and *SessionCleanupInterval* options:
 
 ```csharp
 services.AddBff(options => {

--- a/IdentityServer/v6/docs/content/bff/tokens.md
+++ b/IdentityServer/v6/docs/content/bff/tokens.md
@@ -83,15 +83,10 @@ public async Task<IActionResult> CallApiAsUserTyped(
 The client will internally always try to use a current and valid access token. If for any reason this is not possible, the 401 status code will be returned to the caller. 
 
 ### Reuse of Refresh Tokens
-We recommend that you configure IdentityServer to issue reusable refresh tokens to BFF clients. IdentityServer's refresh tokens by default are one-time use only. For public clients, one-time use refresh tokens are recommended for security reasons. However, the BFF is a confidential client, and confidential clients do not need one-time use refresh tokens (see [OAuth 2.0 Security Best Current Practice](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-2.2.2) for more details). Re-useable refresh tokens are desirable for two reasons:
-
-1. Robustness to network failures. If a one-time use refresh token is used to produce a new token, but the response containing the [new refresh token is lost]({{< ref "/tokens/refresh#one-time-refresh-tokens" >}}) due to a network issue, the client application has no way to recover without the user logging in again. 
-2. Store Performance. One-time use refresh tokens require additional records to be written to the [persisted grants store]({{< ref "/reference/stores/persisted_grant_store">}}) whenever a token is refreshed. Using reusable refresh tokens instead avoids those writes to the grant store.
-
-The reusability of refresh tokens is configured on a per-client basis with the *RefreshTokenUsage* property of the *Client*.
+We recommend that you configure IdentityServer to issue reusable refresh tokens to BFF clients. Because the BFF is a confidential client, it does not need one-time use refresh tokens. Re-useable refresh tokens are desirable because they avoid  performance and user experience problems associated with one time use tokens. See the discussion on rotating refresh tokens]({{< ref "tokens/refresh#one-time-refresh-tokens" >}}) and the [OAuth 2.0 Security Best Current Practice](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-2.2.2) for more details.
 
 ### Manually revoking refresh tokens
-Duende.BFF revokes refresh tokens automatically at logout time (this behavior can be controlled via the options).
+Duende.BFF revokes refresh tokens automatically at logout time. This behavior can be disabled with the *RevokeRefreshTokenOnLogout* option.
 
 If you want to manually revoke the current refresh token, you can use the following code:
 

--- a/IdentityServer/v6/docs/content/data/ef.md
+++ b/IdentityServer/v6/docs/content/data/ef.md
@@ -128,6 +128,10 @@ This options class contains properties to control the operational store and *Per
 *TokenCleanupInterval*
     The token cleanup interval (in seconds). The default is 3600 (1 hour).
 
+*ConsumedTokenCleanupDelay* [Will be added in 6.3]
+    The consumed token cleanup delay (in seconds). The default is 0. This delay is the amount of time that must elapse before tokens marked as consumed can be deleted. Note that only refresh tokens with
+    OneTime usage can be marked as consumed. 
+
 {{% notice note %}}
 The token cleanup feature does *not* remove persisted grants that are *consumed* (see [persisted grants]({{<ref "./operational/grants#grant-expiration-and-consumption">}})). It only removes persisted grants that are beyond their *Expiration*.
 {{% /notice %}}

--- a/IdentityServer/v6/docs/content/reference/options.md
+++ b/IdentityServer/v6/docs/content/reference/options.md
@@ -415,6 +415,11 @@ Shared settings for persisted grants behavior.
     Data protect the persisted grants "data" column. Defaults to *true*.
     If you have PII requirements and your database is already protecting data at rest, then you can consider disabling this.
 
+* ***DeleteOneTimeOnlyRefreshTokensOnUse***
+    (Will be added in 6.3)
+
+    When Refresh tokens that are configured with RefreshTokenUsage.OneTime are used, this option controls if they will be deleted immediately or retained and marked as consumed. The default is on - immediately delete.
+
 ## Dynamic Providers
 Shared settings for the [dynamic providers]({{< ref "/ui/login/dynamicproviders">}}) feature.
 

--- a/IdentityServer/v6/docs/content/reference/services/refresh_token_service.md
+++ b/IdentityServer/v6/docs/content/reference/services/refresh_token_service.md
@@ -27,17 +27,32 @@ public interface IRefreshTokenService
 }
 ```
 
-The logic around refresh token handling is pretty involved, and we don't recommend implementing the interface from scratch,
-unless you exactly know what you are doing.
-If you want to customize certain behavior, it is more recommended to derive from the default implementation and call the base checks first.
+The behavior of the refresh token service is complex. We don't recommend
+implementing the interface from scratch, unless you know exactly know what you
+are doing. If you want to customize how refresh tokens are handled, we
+recommended that you create a class that derives from the default implementation
+and override its virtual methods, calling the methods in the base class before
+adding your own custom logic.
 
-The most common customization that you probably want to do is how to deal with refresh token replays.
-This is for situations where the token usage has been set to one-time only, but the same token gets sent more than once.
-This could either point to a replay attack of the refresh token, or to faulty client code like logic bugs or race conditions.
+The most common customizations to the refresh token service involve how to
+handle consumed tokens. In these situations, the token usage has been set to
+one-time only, but the same token gets sent more than once. This could either
+point to a replay attack of the refresh token, bugs in the client code, or
+transient network failures.
 
-It is important to note, that a refresh token is never deleted in the database. 
-Once it has been used, the *ConsumedTime* property will be set.
-If a token is received that has already been consumed, the default service will call a virtual method called *AcceptConsumedTokenAsync*.
+When one-time use refresh tokens are used, they are not necessarily deleted from
+the database. The DeleteOneTimeOnlyRefreshTokensOnUse configuration flag, which
+will be added in version 6.3, controls if such tokens are immediately deleted or
+consumed. If configured for consumption instead of deletion, then when the token
+is used, the *ConsumedTime* property will be set. If a token is received that
+has already been consumed, the default service will call the
+*AcceptConsumedTokenAsync* virtual method. The purpose of
+*AcceptConsumedTokenAsync* is to determine if a consumed token should be allowed
+to be used to produce new tokens. The default implementation of
+*AcceptConsumedTokenAsync* rejects all consumed tokens, causing the protocol
+request to fail with the "invalid_grant" error. Your customized implementation
+could instead add a grace period to allow recovery after network failures or
+could treat this as a replay attack and take steps to notify the user and/or
+revoke their access.
 
-The default implementation will reject the request, but here you can implement custom logic like grace periods, 
-or revoking additional refresh or access tokens.
+See also: [Refreshing a token]({{< ref "tokens\refresh" >}})

--- a/IdentityServer/v6/docs/content/tokens/refresh.md
+++ b/IdentityServer/v6/docs/content/tokens/refresh.md
@@ -15,7 +15,7 @@ You can request a refresh token by adding a scope called *offline_access* to the
 
 ## Requesting an access token using a refresh token
 To get a new access token, you send the refresh token to the token endpoint.
-This will result in a new token response containing a new access token and its expiration and potentially also a new refresh token depending on the client configuration (see above).
+This will result in a new token response containing a new access token and its expiration and potentially also a new refresh token depending on the client configuration (see [rotation]({{< ref "#rotation" >}})).
 
 ```
 POST /connect/token
@@ -54,22 +54,38 @@ It is recommended that a refresh token is either bound to the client via a clien
 
 The following techniques can be used to reduce the attack surface of refresh tokens.
 
-#### Consent
-It’s a good idea to ask for consent when a client requests a refresh token. This way you at least try to make the user aware of what’s happening, and maybe you also give them a chance to opt-out of it. 
+### Consent
+We encourage you to request consent when a client requests a refresh token, as it not only makes the user aware of the action being taken, but also provides them with an opportunity to opt-out if they choose.
 
-Duende IdentityServer will always ask for consent (if enabled) if the client asks for the *offline_access* scope which goes in-line with the recommendations in the OpenID Connect specification.
+Duende IdentityServer will always ask for consent (if enabled) if the client asks for the *offline_access* scope which follows the recommendations in the OpenID Connect specification.
 
-#### Sliding expiration
+### Sliding expiration
 Refresh tokens usually have a much longer lifetime than access tokens. You can reduce their exposure by adding a sliding lifetime on top of the absolute lifetime. This allows for scenarios where a refresh token can be silently used if the user is regularly using the client, but needs a fresh authorize request if the client has not been used for a certain time. In other words, they auto-expire much quicker without potentially interfering with the typical usage pattern.
 
 You can use the *AbsoluteRefreshTokenLifetime* and *SlidingRefreshTokenLifetime* client settings to fine tune this behavior.
 
-#### One-time Refresh Tokens
-Another option to reduce the exposure of refresh tokens is to rotate them on every usage. Rotation can be configured via the *RefreshTokenUsage* client setting and is enabled by default. As long as it is enabled, refresh tokens are only usable once: every time a refresh token is used, it is marked as consumed and a new refresh token is sent along with the new access token. The new refresh token will have the same creation and expiration time stamps as the previous token.
+### Rotation
+The security of refresh tokens used by public clients can be improved by rotating the tokens on every use. Rotation is configured with the *RefreshTokenUsage* client setting and is enabled by default. However, rotation is only recommended for public clients. For confidential clients, we recommend changing the *RefreshTokenUsage* to allow reusable refresh tokens.
 
-Rotating refresh tokens reduces their attack surface because there is a chance that a stolen token will be unusable by the attacker. If a token is exfiltrated from some storage mechanism, a network trace, or log file, but the owner of the token uses it before the attacker, then the attack fails.
+Public clients need to rotate refresh tokens for security. Rotating refresh tokens reduces their attack surface because there is a chance that a stolen token will be unusable by the attacker. If a token is exfiltrated from some storage mechanism, a network trace, or log file, but the owner of the token uses it before the attacker, then the attack fails. 
 
-The downside of this approach is that you might have more scenarios where a legitimate refresh token becomes unusable. For example, a network problem while refreshing the token could result in the old token being consumed but the new token not delivered to the client, which then will have to authenticate again. To mitigate this problem, you can customize the behavior of the *RefreshTokenService* such that consumed tokens can be used under certain circumstances, perhaps for a small length of time after they are consumed. To do so, create a subclass of the *DefaultRefreshTokenService* and override its *AcceptConsumedTokenAsync(RefreshToken refreshToken)* method. This method takes a consumed refresh token and returns a boolean flag that indicates if that token should be accepted, that is, allowed to be used to obtain an access token. The default implementation in the *DefaultRefreshTokenService* rejects all consumed tokens, but your customized implementation can create a time window where consumed tokens can be used or implement additional revocation logic. 
+When *RefreshTokenUsage* is configured for *OneTime* usage, rotation is enabled and refresh tokens can only be used once. When refresh tokens are used with *OneTime* usage configured, a new refresh token is included in the response along with the new access token. Each time the client application uses the refresh token, it must use the most recent refresh token. This chain of tokens will each appear as distinct token values to the client, but will have identical creation and expiration timestamps in the datastore.
+
+In version 6.3, the configuration option DeleteOneTimeOnlyRefreshTokensOnUse will control what happens to refresh tokens configured for OneTime usage. If the flag is on, then refresh tokens are deleted immediately on use. If the flag is off, the token is marked as consumed instead. Prior to version 6.3, OneTime usage refresh tokens are always marked as consumed.
+
+#### Confidential Clients Should Not Rotate Refresh Tokens
+Confidential clients do not need one-time use refresh tokens because their tokens are bound to the authenticated client. One-time use tokens do not improve the security of confidential clients (see [OAuth 2.0 Security Best Current Practice](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-2.2.2) for more details). 
+
+Reusable refresh tokens are robust to network failures in a way that one time use tokens are not. If a one-time use refresh token is used to produce a new token, but the response containing the new refresh token is lost due to a network issue, the client application has no way to recover without the user logging in again. Reusable refresh tokens do not have this problem.
+
+Reusable tokens may have better performance in the [persisted grants store]({{< ref "/reference/stores/persisted_grant_store">}}). One-time use refresh tokens require additional records to be written to the store whenever a token is refreshed. Using reusable refresh tokens avoids those writes.
+
+#### Accepting Consumed Tokens
+To make one time use tokens more robust to network failures, you can customize the behavior of the *RefreshTokenService* such that consumed tokens can be used under certain circumstances, perhaps for a small length of time after they are consumed. To do so, create a subclass of the *DefaultRefreshTokenService* and override its *AcceptConsumedTokenAsync(RefreshToken refreshToken)* method. This method takes a consumed refresh token and returns a boolean flag that indicates if that token should be accepted, that is, allowed to be used to obtain an access token. The default implementation in the *DefaultRefreshTokenService* rejects all consumed tokens, but your customized implementation could create a time window where consumed tokens can be used.
+
+In 6.3, new options will be added that will interact with this feature. The *PersistentGrantOptions.DeleteOneTimeOnlyRefreshTokensOnUse* flag will cause OneTime refresh tokens to be deleted on use, rather than marked as consumed. This flag will need to be disabled in order to allow a customized Refresh Token Service to use consumed tokens. 
+
+Consumed tokens can be cleaned up by a background process, enabled with the existing *OperationalStoreOptions.EnableTokenCleanup* and *OperationalStoreOptions.RemoveConsumedTokens* flags. Starting in 6.3, the cleanup job can be further configured with the *OperationalStoreOptions.ConsumedTokenCleanupDelay*. This delay is the amount of time that must elapse before tokens marked as consumed will be deleted. If you are customizing the Refresh Token Service to allow for consumed tokens to be used for some period of time, then we recommend configuring the *ConsumedTokenCleanupDelay* to the same time period.
 
 This customization must be registered in the DI system as an implementation of the *IRefreshTokenService*:
 
@@ -77,8 +93,9 @@ This customization must be registered in the DI system as an implementation of t
 builder.Services.TryAddTransient<IRefreshTokenService, YourCustomRefreshTokenService>();
 ```
 
-
 #### Replay detection
-On top of one-time only semantics, you could also layer replay detection. This means that if you ever see the same refresh token used more than once, you could revoke all access to the client/user combination. Again – same caveat applies – while increasing the security, this might result in false positives.
+In addition to one-time only usage semantics, you might wish to add replay detection for refresh tokens. If a refresh token is configured for one-time only use but used multiple times, that means that either the client application is accidentally mis-using the token (a bug), a network failure is preventing the client application from rotating properly (see above), or an attacker is attempting a replay attack. Depending on your security requirements, you might decide to treat this situation as an attack, and take action. What you might do is, if a consumed refresh token is ever used, revoke all access for that client/user combination. This could include deleting refresh tokens, revoking access tokens (if they are introspection tokens), ending the user's server side session, and sending back-channel logout notifications to client applications. You might also consider alerting the user to suspicious activity on their account. Keep in mind that these actions are disruptive and possibly alarming to the user, and there is a potential for false positives.
 
-See the [reference]({{< ref "/reference/services/refresh_token_service" >}}) section for more customization of the refresh token service.
+Implementing replay detection is similar to [accepting consumed tokens](TODO). Extend the *AcceptConsumedTokenAsync* method of the *DefaultRefreshTokenService* and add the additional revocation or alerting behavior that you choose. In 6.3, the same new options that will interact with accepting consumed tokens will also interact with replay detection. The *PersistentGrantOptions.DeleteOneTimeOnlyRefreshTokensOnUse* flag needs to be disabled so that used tokens persist and can be used to detect replays. The cleanup job should also be configured to not delete consumed tokens.
+
+See also: The [IRefreshTokenService]({{< ref "/reference/services/refresh_token_service" >}}) reference.

--- a/IdentityServer/v6/docs/content/ui/server_side_sessions/session_expiration.md
+++ b/IdentityServer/v6/docs/content/ui/server_side_sessions/session_expiration.md
@@ -3,7 +3,7 @@ title: "Session Expiration"
 weight: 20
 ---
 
-If a user abandons their session without triggering logout, then, by default, the server-side session data will remain in the store.
+If a user abandons their session without triggering logout, the server-side session data will remain in the store by default.
 In order to clean up these expired records, there is an automatic cleanup mechanism that periodically scans for expired sessions.
 When these records are cleaned up, you can optionally notify the client that the session has ended via back-channel logout.
 


### PR DESCRIPTION
Closes #229, #226

- Added explanation that refresh tokens should be reused by confidential clients
- Added description of new config DeleteOneTimeOnlyRefreshTokensOnUse
- Added description of new config ConsumedTokenCleanupDelay
- Expanded section on accepting consumed tokens ("lenient" one time use tokens)
- Added section on replay detection
- Links between main page on refresh tokens and reference section on refresh token service
- Edited reference section for clarity
- Shortened the bff section on refresh tokens, moved most of its advice on reuse to the main refresh token page, and link from bff page to moved info