### PR TITLE
Update persisted_grant_service.md to fix spaces.

### DIFF
--- a/IdentityServer/v6/docs/content/reference/services/persisted_grant_service.md
+++ b/IdentityServer/v6/docs/content/reference/services/persisted_grant_service.md
@@ -8,7 +8,7 @@ weight: 43
 Provides access to a user's grants.
 
 ```cs
- /// <summary>
+    /// <summary>
     /// Implements persisted grant logic
     /// </summary>
     public interface IPersistedGrantService


### PR DESCRIPTION
related to #240 
I didn't notice it yesterday when I fixed v5, but the same issue can be found for v6.