### PR TITLE
Fixed typos in defaults

### DIFF
--- a/IdentityServer/v6/docs/content/reference/models/client.md
+++ b/IdentityServer/v6/docs/content/reference/models/client.md
@@ -82,7 +82,7 @@ public static IEnumerable<Client> Get()
 
 * ***AllowPlainTextPkce***
     
-    Specifies whether clients using PKCE can use a plain text code challenge (not recommended - and default to *false*)
+    Specifies whether clients using PKCE can use a plain text code challenge (not recommended - and defaults to *false*)
 
 * ***RedirectUris***
     
@@ -276,8 +276,8 @@ Client initiated backchannel authentication specific settings.
 
 * ***CibaLifetime***
     
-    Specifies the backchannel authentication request lifetime in seconds. Default to *null*.
+    Specifies the backchannel authentication request lifetime in seconds. Defaults to *null*.
 
 * ***PollingInterval***
 
-    Backchannel polling interval in seconds. Default to *null*.
+    Backchannel polling interval in seconds. Defaults to *null*.

--- a/IdentityServer/v6/docs/content/reference/options.md
+++ b/IdentityServer/v6/docs/content/reference/options.md
@@ -140,43 +140,43 @@ Endpoint settings, including flags to disable individual endpoints and support f
 
 * ***EnableAuthorizeEndpoint***
 
-    Enables the authorize endpoint. Default to true.
+    Enables the authorize endpoint. Defaults to true.
 
 * ***EnableTokenEndpoint***
 
-    Enables the token endpoint. Default to true.
+    Enables the token endpoint. Defaults to true.
 
 * ***EnableDiscoveryEndpoint***
 
-    Enables the discovery endpoint. Default to true.
+    Enables the discovery endpoint. Defaults to true.
 
 * ***EnableUserInfoEndpoint***
 
-    Enables the user info endpoint. Default to true.
+    Enables the user info endpoint. Defaults to true.
 
 * ***EnableEndSessionEndpoint***
 
-    Enables the end session endpoint. Default to true.
+    Enables the end session endpoint. Defaults to true.
 
 * ***EnableCheckSessionEndpoint***
 
-    Enables the check session endpoint. Default to true.
+    Enables the check session endpoint. Defaults to true.
 
 * ***EnableTokenRevocationEndpoint***
 
-    Enables the token revocation endpoint. Default to true.
+    Enables the token revocation endpoint. Defaults to true.
 
 * ***EnableIntrospectionEndpoint***
 
-    Enables the introspection endpoint. Default to true.
+    Enables the introspection endpoint. Defaults to true.
 
 * ***EnableDeviceAuthorizationEndpoint***
 
-    Enables the device authorization endpoint. Default to true.
+    Enables the device authorization endpoint. Defaults to true.
 
 * ***EnableBackchannelAuthenticationEndpoint***
 
-    Enables the backchannel authentication endpoint. Default to true.
+    Enables the backchannel authentication endpoint. Defaults to true.
 
 * ***EnableJwtRequestUri***
   Enables the *request_uri* parameter for JWT-Secured Authorization Requests. This allows the JWT to be passed by reference. Disabled by default, due to the security implications of enabling the request_uri parameter (see [RFC 9101 section 10.4](https://datatracker.ietf.org/doc/rfc9101/)).


### PR DESCRIPTION
Minor typo change: "default to false" should be "defaults to false".