### PR TITLE
Expand upgrade guides discussion of sql

### DIFF
--- a/IdentityServer/v6/docs/content/key_rotation.md
+++ b/IdentityServer/v6/docs/content/key_rotation.md
@@ -1,7 +1,0 @@
-# Key Rotation
-
-Signing keys should be rotated periodically. 
-
-## Problems
-
-## Solutions

--- a/IdentityServer/v6/docs/content/upgrades/is4_v4_to_dis_v5.md
+++ b/IdentityServer/v6/docs/content/upgrades/is4_v4_to_dis_v5.md
@@ -51,9 +51,15 @@ This includes:
 * A new *Keys* table for the automatic key management feature in the operational database.
 * A new *RequireResourceIndicator* boolean column on the *ApiResources* table in the configuration database.
 
-If you are using the *Duende.IdentityServer.EntityFramework* package as the implementation for the database and you're using EntityFramework Core migrations as the mechanism for managing those schema changes over time, the commands below will update those migrations with the new changes.
-Note that you might need to adjust based on your specific organization of the migration files.
+IdentityServer is abstracted from the data store on multiple levels, so the exact steps involved in updating your data store will depend on your implementation details. 
 
+#### Custom Store Implementations
+The core of IdentityServer is written against the [store interfaces]({{<ref "reference/stores" >}}), which abstract all the implementation details of actually storing data. If your IdentityServer implementation includes a custom implementation of those stores, then you will have to determine how best to include the changes in the model in the underlying data store and make any necessary changes to schemas, if your data store requires that.
+
+#### Duende.IdentityServer.EntityFramework
+We also provide a default implementation of the stores in the *Duende.IdentityServer.EntityFramework* package, but this implementation is still highly abstracted because it is usable with any database that has an EF provider. Different database vendors have very different dialects of sql that have different syntax and type systems, so we don't provide schema changes directly. Instead, we provide the Entity Framework entities and mappings which can be used with Entity Framework's migrations feature to generate the schema updates that are needed in your database. 
+
+To generate migrations, run the commands below. Note that you might need to adjust paths based on your specific organization of the migration files.
 ```
 dotnet ef migrations add UpdateToDuende_v5 -c PersistedGrantDbContext -o Data/Migrations/IdentityServer/PersistedGrantDb
 
@@ -67,6 +73,8 @@ dotnet ef database update -c PersistedGrantDbContext
 
 dotnet ef database update -c ConfigurationDbContext
 ```
+
+Some organizations prefer to use other tools for managing schema changes. You're free to manage your schema however you see fit, as long as the entities can be successfully mapped. Even if you're not going to ultimately use Entity Framework migrations to manage your database changes, generating a migration can be a useful development step to get an idea of what needs to be done.
 
 ## Step 5: Migrating signing keys (optional)
 

--- a/IdentityServer/v6/docs/content/upgrades/is4_v4_to_dis_v6.md
+++ b/IdentityServer/v6/docs/content/upgrades/is4_v4_to_dis_v6.md
@@ -79,9 +79,15 @@ These include:
 * Add missing columns for created, updated, etc to EF entities ([more details](https://github.com/DuendeSoftware/IdentityServer/pull/356)).
 * Add unique constraints to EF tables where duplicate records not allowed ([more details](https://github.com/DuendeSoftware/IdentityServer/pull/355)).
 
+IdentityServer is abstracted from the data store on multiple levels, so the exact steps involved in updating your data store will depend on your implementation details. 
 
-If you are using the *Duende.IdentityServer.EntityFramework* package as the implementation for the database and you're using EntityFramework Core migrations as the mechanism for managing those schema changes over time, the commands below will update those migrations with the new changes.
-Note that you might need to adjust based on your specific organization of the migration files.
+#### Custom Store Implementations
+The core of IdentityServer is written against the [store interfaces]({{<ref "reference/stores" >}}), which abstract all the implementation details of actually storing data. If your IdentityServer implementation includes a custom implementation of those stores, then you will have to determine how best to include the changes in the model in the underlying data store and make any necessary changes to schemas, if your data store requires that.
+
+#### Duende.IdentityServer.EntityFramework
+We also provide a default implementation of the stores in the *Duende.IdentityServer.EntityFramework* package, but this implementation is still highly abstracted because it is usable with any database that has an EF provider. Different database vendors have very different dialects of sql that have different syntax and type systems, so we don't provide schema changes directly. Instead, we provide the Entity Framework entities and mappings which can be used with Entity Framework's migrations feature to generate the schema updates that are needed in your database. 
+
+To generate migrations, run the commands below. Note that you might need to adjust paths based on your specific organization of the migration files.
 
 ```
 dotnet ef migrations add UpdateToDuende_v6_0 -c PersistedGrantDbContext -o Data/Migrations/IdentityServer/PersistedGrantDb
@@ -100,6 +106,8 @@ dotnet ef database update -c PersistedGrantDbContext
 
 dotnet ef database update -c ConfigurationDbContext
 ```
+
+Some organizations prefer to use other tools for managing schema changes. You're free to manage your schema however you see fit, as long as the entities can be successfully mapped. Even if you're not going to ultimately use Entity Framework migrations to manage your database changes, generating a migration can be a useful development step to get an idea of what needs to be done.
 
 ## Step 6: Migrating signing keys (optional)
 

--- a/IdentityServer/v6/docs/content/upgrades/v5.0_to_v5.1.md
+++ b/IdentityServer/v6/docs/content/upgrades/v5.0_to_v5.1.md
@@ -22,12 +22,12 @@ would change to:
 
 ## Step 2: Update Database Schema (if needed)
 
-If you are using a [database]({{<ref "/data">}}) for your operational data, then there is a small database schema update.
+If you are using the *Duende.IdentityServer.EntityFramework* package as the implementation for the database for your operational data, then there is a small database schema update.
 This includes:
 
 * A new index on the *ConsumedTime* column in the *PersistedGrants* table ([more details](https://github.com/DuendeSoftware/IdentityServer/pull/84)).
 
-If you are using the *Duende.IdentityServer.EntityFramework* package as the implementation for the database and you're using EntityFramework Core migrations as the mechanism for managing those schema changes over time, the commands below will update those migrations with the new changes.
+If you're using EntityFramework Core migrations as the mechanism for managing schema changes over time, the commands below will update those migrations with the new changes.
 Note that you might need to adjust based on your specific organization of the migration files.
 
 ```
@@ -39,6 +39,8 @@ Then to apply those changes to your database:
 ```
 dotnet ef database update -c PersistedGrantDbContext
 ```
+
+Some organizations prefer to use other tools for managing schema changes. You're free to manage your schema however you see fit, as long as the entities can be successfully mapped. Even if you're not going to ultimately use Entity Framework migrations to manage your database changes, generating a migration can be a useful development step to get an idea of what needs to be done.
 
 ## Step 3: Done!
 

--- a/IdentityServer/v6/docs/content/upgrades/v5.1_to_v5.2.md
+++ b/IdentityServer/v6/docs/content/upgrades/v5.1_to_v5.2.md
@@ -39,8 +39,14 @@ CREATE TABLE [IdentityProviders] (
 );
 ```
 
-If you are using the *Duende.IdentityServer.EntityFramework* package as the implementation for the database and you're using EntityFramework Core migrations as the mechanism for managing those schema changes over time, the commands below will update those migrations with the new changes.
-Note that you might need to adjust based on your specific organization of the migration files.
+IdentityServer is abstracted from the data store on multiple levels, so the exact steps involved in updating your data store will depend on your implementation details. 
+#### Custom Store Implementations
+The core of IdentityServer is written against the [store interfaces]({{<ref "reference/stores" >}}), which abstract all the implementation details of actually storing data. If your IdentityServer implementation includes a custom implementation of those stores, then you will have to determine how best to include the changes in the model in the underlying data store and make any necessary changes to schemas, if your data store requires that.
+
+#### Duende.IdentityServer.EntityFramework
+We also provide a default implementation of the stores in the *Duende.IdentityServer.EntityFramework* package, but this implementation is still highly abstracted because it is usable with any database that has an EF provider. Different database vendors have very different dialects of sql that have different syntax and type systems, so we don't provide schema changes directly. Instead, we provide the Entity Framework entities and mappings which can be used with Entity Framework's migrations feature to generate the schema updates that are needed in your database. 
+
+To generate a migration, run the command below. Note that you might need to adjust paths based on your specific organization of the migration files.
 
 ```
 dotnet ef migrations add Update_DuendeIdentityServer_v5_2 -c ConfigurationDbContext -o Data/Migrations/IdentityServer/ConfigurationDb
@@ -51,6 +57,8 @@ Then to apply those changes to your database:
 ```
 dotnet ef database update -c ConfigurationDbContext
 ```
+
+Some organizations prefer to use other tools for managing schema changes. You're free to manage your schema however you see fit, as long as the entities can be successfully mapped. Even if you're not going to ultimately use Entity Framework migrations to manage your database changes, generating a migration can be a useful development step to get an idea of what needs to be done.
 
 ## Step 4: Update custom AuthorizeInteractionResponseGenerator (if needed)
 

--- a/IdentityServer/v6/docs/content/upgrades/v5.2_to_v6.0.md
+++ b/IdentityServer/v6/docs/content/upgrades/v5.2_to_v6.0.md
@@ -53,9 +53,15 @@ This includes:
 
 * Add missing columns for created, updated, etc to EF entities ([more details](https://github.com/DuendeSoftware/IdentityServer/pull/356)).
 * Add unique constraints to EF tables where duplicate records not allowed ([more details](https://github.com/DuendeSoftware/IdentityServer/pull/355)).
+IdentityServer is abstracted from the data store on multiple levels, so the exact steps involved in updating your data store will depend on your implementation details. 
 
-If you are using the *Duende.IdentityServer.EntityFramework* package as the implementation for the database and you're using EntityFramework Core migrations as the mechanism for managing those schema changes over time, the commands below will update those migrations with the new changes.
-Note that you might need to adjust based on your specific organization of the migration files.
+#### Custom Store Implementations
+The core of IdentityServer is written against the [store interfaces]({{<ref "reference/stores" >}}), which abstract all the implementation details of actually storing data. If your IdentityServer implementation includes a custom implementation of those stores, then you will have to determine how best to include the changes in the model in the underlying data store and make any necessary changes to schemas, if your data store requires that.
+
+#### Duende.IdentityServer.EntityFramework
+We also provide a default implementation of the stores in the *Duende.IdentityServer.EntityFramework* package, but this implementation is still highly abstracted because it is usable with any database that has an EF provider. Different database vendors have very different dialects of sql that have different syntax and type systems, so we don't provide schema changes directly. Instead, we provide the Entity Framework entities and mappings which can be used with Entity Framework's migrations feature to generate the schema updates that are needed in your database. 
+
+To generate a migration, run the command below. Note that you might need to adjust paths based on your specific organization of the migration files.
 
 ```
 dotnet ef migrations add Update_DuendeIdentityServer_v6_0 -c ConfigurationDbContext -o Data/Migrations/IdentityServer/ConfigurationDb
@@ -71,6 +77,7 @@ Then to apply those changes to your database:
 dotnet ef database update -c ConfigurationDbContext
 ```
 
+Some organizations prefer to use other tools for managing schema changes. You're free to manage your schema however you see fit, as long as the entities can be successfully mapped. Even if you're not going to ultimately use Entity Framework migrations to manage your database changes, generating a migration can be a useful development step to get an idea of what needs to be done.
 
 ## Step 4: Verify Data Protection Configuration
 IdentityServer depends on ASP.NET Data Protection. Data Protection encrypts and signs data using keys managed by ASP.NET. Those keys are isolated by application name, which by default is set to the content root path of the host. This prevents multiple applications from sharing encryption keys, which is necessary to protect your encryption against certain forms of attack. However, this means that if your content root path changes, the default settings for data protection will prevent you from using your old keys. Beginning in .NET 6, the content root path is now normalized so that it ends with a directory separator. This means that your content root path might change when you upgrade to .NET 6. This can be mitigated by explicitly setting the application name and removing the separator character. See [Microsoft's documentation for more information](https://learn.microsoft.com/en-us/aspnet/core/security/data-protection/configuration/overview?view=aspnetcore-6.0#setapplicationname).

--- a/IdentityServer/v6/docs/content/upgrades/v6.0_to_v6.1.md
+++ b/IdentityServer/v6/docs/content/upgrades/v6.0_to_v6.1.md
@@ -22,15 +22,22 @@ would change to:
 
 ## Step 2: Update Database Schema (if needed)
 
-If you are using a [database]({{<ref "/data">}}) for your operational data, then there is a database schema update.
+If you are using a [database]({{<ref "/data">}}) for your configuration or operational data, then there is a database schema update.
 This includes:
 
 * Server-side sessions feature, which requires a new table ([more details](https://github.com/DuendeSoftware/IdentityServer/pull/743)).
 * Session coordination feature, which adds a column to the Clients table ([more details](https://github.com/DuendeSoftware/IdentityServer/pull/820)).
 * Improve primary key on the persisted grants table ([more details](https://github.com/DuendeSoftware/IdentityServer/pull/793)).
 
-If you are using the *Duende.IdentityServer.EntityFramework* package as the implementation for the database and you're using EntityFramework Core migrations as the mechanism for managing those schema changes over time, the commands below will update those migrations with the new changes.
-Note that you might need to adjust based on your specific organization of the migration files.
+IdentityServer is abstracted from the data store on multiple levels, so the exact steps involved in updating your data store will depend on your implementation details. 
+
+#### Custom Store Implementations
+The core of IdentityServer is written against the [store interfaces]({{<ref "reference/stores" >}}), which abstract all the implementation details of actually storing data. If your IdentityServer implementation includes a custom implementation of those stores, then you will have to determine how best to include the changes in the model in the underlying data store and make any necessary changes to schemas, if your data store requires that.
+
+#### Duende.IdentityServer.EntityFramework
+We also provide a default implementation of the stores in the *Duende.IdentityServer.EntityFramework* package, but this implementation is still highly abstracted because it is usable with any database that has an EF provider. Different database vendors have very different dialects of sql that have different syntax and type systems, so we don't provide schema changes directly. Instead, we provide the Entity Framework entities and mappings which can be used with Entity Framework's migrations feature to generate the schema updates that are needed in your database. 
+
+To generate migrations, run the commands below. Note that you might need to adjust paths based on your specific organization of the migration files.
 
 ```
 dotnet ef migrations add Update_DuendeIdentityServer_v6_1 -c ConfigurationDbContext -o Data/Migrations/IdentityServer/ConfigurationDb
@@ -43,6 +50,8 @@ Then to apply those changes to your database:
 dotnet ef database update -c ConfigurationDbContext
 dotnet ef database update -c PersistedGrantDbContext
 ```
+
+Some organizations prefer to use other tools for managing schema changes. You're free to manage your schema however you see fit, as long as the entities can be successfully mapped. Even if you're not going to ultimately use Entity Framework migrations to manage your database changes, generating a migration can be a useful development step to get an idea of what needs to be done.
 
 ## Step 3: Done!
 

--- a/IdentityServer/v6/docs/content/upgrades/v6.2_to_v6.3.md
+++ b/IdentityServer/v6/docs/content/upgrades/v6.2_to_v6.3.md
@@ -51,8 +51,15 @@ IdentityServer 6.3 adds new four new properties to the [*Duende.IdentityServer.M
   * *DPoPValidationMode* is a non-nullable column that stores a "flags"-style enum that controls the DPoP validation mechanism. In most databases, this is represented as an integer. Existing clients that are not using DPoP can set its value to 0.
   * *DPoPClockSkew* is a non-nullable timespan that controls how much clock skew is allowed for a particular DPoP client. Existing clients that are not using DPoP can set its value to a timespan of length 0.
 
-If you are using the *Duende.IdentityServer.EntityFramework* package as the implementation for the database and you're using EntityFramework Core migrations as the mechanism for managing its schema changes, the command below will create a migration for the new columns.
-Note that you might need to adjust paths based on your specific organization of the migration files.
+IdentityServer is abstracted from the data store on multiple levels, so the exact steps involved in updating your data store will depend on your implementation details. 
+
+#### Custom Store Implementations
+The core of IdentityServer is written against the [store interfaces]({{<ref "reference/stores" >}}), which abstract all the implementation details of actually storing data. If your IdentityServer implementation includes a custom implementation of those stores, then you will have to determine how best to include the changes in the model in the underlying data store and make any necessary changes to schemas, if your data store requires that.
+
+#### Duende.IdentityServer.EntityFramework
+We also provide a default implementation of the stores in the *Duende.IdentityServer.EntityFramework* package, but this implementation is still highly abstracted because it is usable with any database that has an EF provider. Different database vendors have very different dialects of sql that have different syntax and type systems, so we don't provide schema changes directly. Instead, we provide the Entity Framework entities and mappings which can be used with Entity Framework's migrations feature to generate the schema updates that are needed in your database. 
+
+To generate a migration for the new columns, run the command below. Note that you might need to adjust paths based on your specific organization of the migration files.
 
 ```
 dotnet ef migrations add Update_DuendeIdentityServer_v6_3 -c ConfigurationDbContext -o Migrations/ConfigurationDb
@@ -63,6 +70,8 @@ Then to apply this migration to your database:
 ```
 dotnet ef database update -c ConfigurationDbContext
 ```
+
+Some organizations prefer to use other tools for managing schema changes. You're free to manage your schema however you see fit, as long as the entities can be successfully mapped. Even if you're not going to ultimately use Entity Framework migrations to manage your database changes, generating a migration can be a useful development step to get an idea of what needs to be done.
 
 ## Step 3: Verify Data Protection Configuration
 IdentityServer depends on ASP.NET Data Protection. Data Protection encrypts and signs data using keys managed by ASP.NET. Those keys are isolated by application name, which by default is set to the content root path of the host. This prevents multiple applications from sharing encryption keys, which is necessary to protect your encryption against certain forms of attack. However, this means that if your content root path changes, the default settings for data protection will prevent you from using your old keys. Beginning in .NET 6, the content root path was normalized so that it ends with a directory separator. In .NET 7 that change was reverted. This means that your content root path might change if you upgrade from .NET 6 to .NET 7. This can be mitigated by explicitly setting the application name and removing the separator character. See [Microsoft's documentation for more information](https://learn.microsoft.com/en-us/aspnet/core/security/data-protection/configuration/overview?view=aspnetcore-7.0#setapplicationname).


### PR DESCRIPTION
- Explain why we don't publish sql
- Explain what is needed if you have a custom store vs use the EF store
- Note that the EF migration can be helpful even if you're managing schema with other tools