### PR TITLE
Update 0_overview.md

### DIFF
--- a/IdentityServer/v6/docs/content/quickstarts/0_overview.md
+++ b/IdentityServer/v6/docs/content/quickstarts/0_overview.md
@@ -19,7 +19,7 @@ Every quickstart has a reference solution - you can find the code in the [sample
 The first thing you should do is install our templates:
 
 ```
-dotnet new --install Duende.IdentityServer.Templates
+dotnet new install Duende.IdentityServer.Templates
 ```
 
 They will be used as a starting point for the various tutorials.


### PR DESCRIPTION
Adjust dotnet new syntax for new format to avoid below warning.

> Warning: use of 'dotnet new --install' is deprecated. Use 'dotnet new install' instead.