### PR TITLE
Joe/samples-index

### DIFF
--- a/IdentityServer/v6/docs/config.toml
+++ b/IdentityServer/v6/docs/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/identityserver/v6"
+baseURL = "https://docs.duendesoftware.com/identityserver/v6"
 languageCode = "en-us"
 title = "Duende IdentityServer Documentation"
 

--- a/IdentityServer/v6/docs/content/samples/_index.md
+++ b/IdentityServer/v6/docs/content/samples/_index.md
@@ -6,13 +6,13 @@ chapter = true
 
 # Samples
 
-We have a collection of runnable samples for various scenarios. Each sample typically self contained with both an IdentityServer instance and
-clients/APIs needed to demonstrate the functionality.
+We have a collection of runnable samples that show how to use IdentityServer and configure client applications in a variety of scenarios. Most of the samples include both their own IdentityServer implementation and the
+clients and APIs needed to demonstrate the illustrated functionality. The "Basics" samples use a [shared IdentityServer implementation]({{< param samples_base >}}/Basics/IdentityServer), and some of the BFF samples use our public [demo instance of IdentityServer](https://demo.duendesoftware.com/).
 
 {{%children style="li" /%}}
 
-The source code for the samples are in our samples [repository]({{< param samples_base >}}).
+The source code for the samples is in our samples [repository]({{< param samples_base >}}).
 
-Feel free to open a new Bff or IdentityServer [issue ](https://github.com/DuendeSoftware/Support/issues/new/choose) if you are looking for a particular sample, and can't find it here.
+Feel free to open a new BFF or IdentityServer [issue ](https://github.com/DuendeSoftware/Support/issues/new/choose) if you are looking for a particular sample and can't find it here.
 
 


### PR DESCRIPTION
This is some minor copy editing/a small clarification on the samples page.

I'm also reverting a change to the config.toml related to base urls. The base url change was made to test search in the stage environment. However, that breaks my local environment, and search is now deployed