### PR TITLE
Corrected discussion of session options

### DIFF
--- a/IdentityServer/v6/docs/content/ui/server_side_sessions/session_expiration.md
+++ b/IdentityServer/v6/docs/content/ui/server_side_sessions/session_expiration.md
@@ -10,7 +10,7 @@ When these records are cleaned up, you can optionally notify the client that the
 ## Expiration Configuration
 
 The expiration configuration features can be configured with the [server-side session options]({{<ref "/reference/options#server-side-sessions">}}).
-It is enabled by default, but if you wish to disable it or change the frequency it runs you can. 
+It is enabled by default, but if you wish to disable it or change how often IdentityServer will check for expired sessions, you can. 
 
 For example:
 
@@ -25,18 +25,7 @@ public void ConfigureServices(IServiceCollection services)
 ```
 
 ### Back-channel Logout
-When these expired records are removed you can optionally trigger [back-channel logout notification]({{<ref "/ui/logout/notification#back-channel-server-side-clients">}}). 
-To do so, you must enable the feature with the *ExpiredSessionsTriggerBackchannelLogout* option on the [server-side session options]({{<ref "/reference/options#server-side-sessions">}}). 
-This is not enabled by default.
+When the session cleanup job removes expired records, it will by default also trigger [back-channel logout notifications]({{<ref "/ui/logout/notification#back-channel-server-side-clients">}}) to client applications participating in the session. You can use this mechanism to create an [inactivity timeout]({{<ref "inactivity_timeout">}}) that applies across all your client applications.
 
-For example:
+The *ServerSideSessions.ExpiredSessionsTriggerBackchannelLogout* flag enables this behavior, and it is on by default.
 
-```cs
-public void ConfigureServices(IServiceCollection services)
-{
-    services.AddIdentityServer(options => {
-        options.ServerSideSessions.ExpiredSessionsTriggerBackchannelLogout = true;
-    })
-        .AddServerSideSessions();
-}
-```


### PR DESCRIPTION
ExpiredSessionsTriggerBackchannelLogout is on by default.

See https://github.com/DuendeSoftware/Support/issues/838