### PR TITLE
Typo corrected

### DIFF
--- a/IdentityServer/v6/docs/content/apis/aspnetcore/reference.md
+++ b/IdentityServer/v6/docs/content/apis/aspnetcore/reference.md
@@ -19,7 +19,7 @@ services.AddAuthentication("token")
 ```
 
 ## Supporting both JWTs and reference tokens
-It is not uncommon to use the same API with both JWTs and reference tokens. In this case you setup to authentication handlers, make one the default handler and provide some forwarding logic, e.g.:
+It is not uncommon to use the same API with both JWTs and reference tokens. In this case you setup 2 authentication handlers, make one the default handler and provide some forwarding logic, e.g.:
 
 ```cs
 services.AddAuthentication("token")


### PR DESCRIPTION
It took me some time to understand that "to" is mistyping "two". Writing the number 2 may be even clearer.