### PR TITLE
Fix duplicate heading

### DIFF
--- a/IdentityServer/v6/docs/content/ui/login/mfa.md
+++ b/IdentityServer/v6/docs/content/ui/login/mfa.md
@@ -3,8 +3,6 @@ title: "Multi Factor Authentication"
 weight: 50
 ---
 
-# Multi Factor Authentication
-
 IdentityServer itself doesn't implement MFA. MFA is part of the login which is the [responsibility of the hosting application]({{< ref "..">}}).
 
 ## MFA hosted in IdentityServer


### PR DESCRIPTION
Heading is already created by the page title... no need to repeat the same large header twice.