### PR TITLE
Migrations in upgrade guide v7

### DIFF
--- a/IdentityServer/v7/docs/content/upgrades/v6.3_to_v7.0.md
+++ b/IdentityServer/v7/docs/content/upgrades/v6.3_to_v7.0.md
@@ -4,7 +4,7 @@ weight: 40
 ---
 
 {{% notice note %}}
-This upgrade guide is work in progress based on the currently available [preview version of v7.0](https://github.com/DuendeSoftware/IdentityServer/releases/tag/7.0.0-preview.1).
+This upgrade guide is work in progress based on the currently available [preview version of v7.0](https://github.com/DuendeSoftware/IdentityServer/releases/tag/7.0.0-preview.2).
 {{% /notice %}}
 
 ## What's New
@@ -22,12 +22,10 @@ For example in your project file:
 would change to: 
 
 ```
-<PackageReference Include="Duende.IdentityServer" Version="7.0-preview.1" />
+<PackageReference Include="Duende.IdentityServer" Version="7.0-preview.2" />
 ```
 
 ## Step 2: Update Database Schema (if necessary)
-
-TODO
 
 IdentityServer is abstracted from the data store on multiple levels, so the exact steps involved in updating your data store will depend on your implementation details. 
 
@@ -39,21 +37,48 @@ We also provide a default implementation of the stores in the *Duende.IdentitySe
 
 To generate a migration for the new columns, run the command below. Note that you might need to adjust paths based on your specific organization of the migration files.
 
-```
-dotnet ef migrations add Update_DuendeIdentityServer_v7_0_preview_1 -c ConfigurationDbContext -o Migrations/ConfigurationDb
+```shell
+dotnet ef migrations add Update_DuendeIdentityServer_v7_0_preview_2 -c ConfigurationDbContext -o Migrations/ConfigurationDb
+
+dotnet ef migrations add Update_DuendeIdentityServer_v7_0_preview_2 -c PersistedGrantDbContext -o Migrations/PersistedGrantDb
 ```
 
-Then to apply this migration to your database:
+The ServerSideSession.Id property has been changed from `int` to `long`. The migrations created handles the data type change, but fails to drop and re-create the primary key. If the primary key constraint is not removed, running the migration fails. The primary key of the table needs to be dropped before the alter and then recreated. The easiest is to update the generated migrations file:
 
 ```
+
+// Add this line before AlterColumn
+migrationBuilder.DropPrimaryKey("PK_ServerSideSessions", "ServerSideSessions");
+
+// This should already be in the generated code
+migrationBuilder.AlterColumn<long>(
+    name: "Id",
+    table: "ServerSideSessions",
+    type: "bigint",
+    nullable: false,
+    oldClrType: typeof(int),
+    oldType: "int")
+    .Annotation("SqlServer:Identity", "1, 1")
+    .OldAnnotation("SqlServer:Identity", "1, 1");
+
+// Add this after AlterColumn
+migrationBuilder.AddPrimaryKey("PK_ServerSideSessions", "ServerSideSessions", "Id");
+
+```
+
+{{% notice info %}}
+ For most deployments the approach above will work. For deployments with high volumes of sessions, high availability demands and no low traffic hours this might be cause unacceptable downtime. The impact and possible workarounds depends on the database engine used.
+{{% /notice %}}
+
+Once you've updated the migration, they can be applied to your database:
+
+```shell
 dotnet ef database update -c ConfigurationDbContext
+
+dotnet ef database update -c PersistedGrantDbContext
 ```
 
 Some organizations prefer to use other tools for managing schema changes. You're free to manage your schema however you see fit, as long as the entities can be successfully mapped. Even if you're not going to ultimately use Entity Framework migrations to manage your database changes, generating a migration can be a useful development step to get an idea of what needs to be done.
-
-{{% notice info %}}
-The ServerSideSession.Id property has been changed from `int` to `long`. For most deployments this will be handled by the EF generated migration scripts. For deployments with high volumes of sessions, high availability demands and no low traffic hours this might be a problem. The impact and possible workarounds depends on the database engine used.
-{{% /notice %}}
 
 ## Step 3: Breaking changes
 * A new interface *IIdentityServerTools* has been introduced for the *IdentityServerTools* helper class to allow mocking. Update any direct references to *IdentityServerTools* to *IIdentityServerTools*.


### PR DESCRIPTION
PK_ServerSideSessions is not dropped/recreated automatically. This is a known limitation of EF Core https://github.com/dotnet/efcore/issues/30570