### PR TITLE
docs/fix-faulty-dotnet-install-command

### DIFF
--- a/IdentityServer/v7/docs/content/quickstarts/0_overview.md
+++ b/IdentityServer/v7/docs/content/quickstarts/0_overview.md
@@ -20,7 +20,7 @@ Every quickstart has a reference solution - you can find the code in the [sample
 The first thing you should do is install our templates:
 
 ```
-dotnet new -install Duende.IdentityServer.Templates
+dotnet new install Duende.IdentityServer.Templates
 ```
 
 They will be used as a starting point for the various tutorials.

--- a/IdentityServer/v7/docs/content/quickstarts/1_client_credentials.md
+++ b/IdentityServer/v7/docs/content/quickstarts/1_client_credentials.md
@@ -28,7 +28,7 @@ the quickstarts. To install the templates open a console window and type the
 following command:
 
 ```console
-dotnet new -install Duende.IdentityServer.Templates
+dotnet new install Duende.IdentityServer.Templates
 ```
 
 ## Create the Solution and IdentityServer Project


### PR DESCRIPTION
The command to install templates in docs state:
dotnet new -install Duende.IdentityServer.Templates

When it should be:
dotnet new install Duende.IdentityServer.Templates