### PR TITLE
Include DisableTelemetry in example usage of AddOpenIdConnect

### DIFF
--- a/IdentityServer/v7/docs/content/tokens/requesting.md
+++ b/IdentityServer/v7/docs/content/tokens/requesting.md
@@ -172,7 +172,7 @@ Pragma: no-cache
 {
     "id_token": "...",
     "access_token": "...",
-    "refresh_token": "..."
+    "refresh_token": "...",
     "token_type": "bearer",
     "expires_in": 3600,
 }
@@ -215,6 +215,9 @@ public void ConfigureServices(IServiceCollection services)
                 NameClaimType = "name",
                 RoleClaimType = "role"
             };
+
+            // Disable x-client-SKU and x-client-ver headers 
+            options.DisableTelemetry = true;
         });
 }
 ```


### PR DESCRIPTION
Actually in most cases where we add the OIDC handler, we either omit most options, or it is in the context of a a quickstart tutorial where I think extra options distract from the tutorial.  So we only really need to do this in one place

See DuendeSoftware/Samples#183