### PR TITLE
Typo in defining the client chapter

### DIFF
--- a/IdentityServer/v7/docs/content/quickstarts/1_client_credentials.md
+++ b/IdentityServer/v7/docs/content/quickstarts/1_client_credentials.md
@@ -147,7 +147,7 @@ Add this client definition to *Config.cs*:
 
 ```cs
 public static IEnumerable<Client> Clients =>
-    new Client
+    new Client[]
     
     {
         new Client


### PR DESCRIPTION
Adding the code in `Defining the client' in the project resulted in project errors due to misalignments between the code and what was documented

```
Cannot initialize type 'Client' with a collection initializer because it does not implement 'System.Collections.IEnumerable
```
