### PR TITLE
fix typo in docs IdentiyServer v7

### DIFF
--- a/IdentityServer/v7/docs/content/quickstarts/1_client_credentials.md
+++ b/IdentityServer/v7/docs/content/quickstarts/1_client_credentials.md
@@ -147,8 +147,7 @@ Add this client definition to *Config.cs*:
 
 ```cs
 public static IEnumerable<Client> Clients =>
-    new Client
-    
+    new Client[]
     {
         new Client
         {


### PR DESCRIPTION
fix a typo in the sample on this page https://docs.duendesoftware.com/identityserver/v7/quickstarts/1_client_credentials/#define-client. 
It should be `new Client[]` instead of `new Client`