### PR TITLE
Mention subject exception with serversidesessions enabled

### DIFF
--- a/IdentityServer/v7/docs/content/reference/services/profile_service.md
+++ b/IdentityServer/v7/docs/content/reference/services/profile_service.md
@@ -31,58 +31,58 @@ public interface IProfileService
 }
 ```
 
-* ***GetProfileDataAsync***
-    
-    The API that is expected to load claims for a user. It is passed an instance of *ProfileDataRequestContext*.
+- **_GetProfileDataAsync_**
 
-* ***IsActiveAsync***
-    
-    The API that is expected to indicate if a user is currently allowed to obtain tokens. It is passed an instance of *IsActiveContext*.
+  The API that is expected to load claims for a user. It is passed an instance of _ProfileDataRequestContext_.
+
+- **_IsActiveAsync_**
+  The API that is expected to indicate if a user is currently allowed to obtain tokens. It is passed an instance of _IsActiveContext_.
 
 #### Duende.IdentityServer.Models.ProfileDataRequestContext
 
 Models the request for user claims and is the vehicle to return those claims. It contains these properties:
 
-* ***Subject***
-    
-    The *ClaimsPrincipal* modeling the user associated with this request for profile data. When the profile service is invoked for tokens, the *Subject* property will contain the principal that was issued during user sign-in. When the profile service is called for requests to the [userinfo endpoint]({{< ref "/reference/endpoints/userinfo" >}}), the *Subject* property will contain a claims principal populated with the claims in the access token used to authorize the userinfo call.
+- **_Subject_**
 
-* ***Client***
-    
-    The *Client* for which the claims are being requested.
+  The _ClaimsPrincipal_ modeling the user associated with this request for profile data. When the profile service is invoked for tokens, the _Subject_ property will contain the principal that was issued during user sign-in. When the profile service is called for requests to the [userinfo endpoint]({{< ref "/reference/endpoints/userinfo" >}}), the _Subject_ property will contain a claims principal populated with the claims in the access token used to authorize the userinfo call.
 
-* ***RequestedClaimTypes***
-    
-    The collection of claim types being requested. This data is source from the requested scopes and their associated claim types.
+  When the [server-side sessions feature]({{< ref "ui/server_side_sessions/" >}}) is enabled _Subject_ will always contain the claims in the session.
 
-* ***Caller***
-    
-    An identifier for the context in which the claims are being requested (e.g. an identity token, an access token, or the user info endpoint). The *IdentityServerConstants.ProfileDataCallers* class contains the different constant values.
+- **_Client_**
 
-* ***IssuedClaims***
+  The _Client_ for which the claims are being requested.
 
-    The list of claims that will be returned. This is expected to be populated by the custom *IProfileService* implementation.
+- **_RequestedClaimTypes_**
 
-* ***AddRequestedClaims***
+  The collection of claim types being requested. This data is source from the requested scopes and their associated claim types.
 
-    Extension method on the *ProfileDataRequestContext* to populate the *IssuedClaims*, but first filters the claims based on *RequestedClaimTypes*.
+- **_Caller_**
+
+  An identifier for the context in which the claims are being requested (e.g. an identity token, an access token, or the user info endpoint). The _IdentityServerConstants.ProfileDataCallers_ class contains the different constant values.
+
+- **_IssuedClaims_**
+
+  The list of claims that will be returned. This is expected to be populated by the custom _IProfileService_ implementation.
+
+- **_AddRequestedClaims_**
+
+  Extension method on the _ProfileDataRequestContext_ to populate the _IssuedClaims_, but first filters the claims based on _RequestedClaimTypes_.
 
 #### Duende.IdentityServer.Models.IsActiveContext
 
 Models the request to determine if the user is currently allowed to obtain tokens. It contains these properties:
 
-* ***Subject***
-    
-    The *ClaimsPrincipal* modeling the user.
+- **_Subject_**
 
-* ***Client***
-    
-    The *Client* for which the claims are being requested.
+  The _ClaimsPrincipal_ modeling the user.
 
-* ***Caller***
-    
-    An identifier for the context in which the claims are being requested (e.g. an identity token, an access token, or the user info endpoint. The constant *IdentityServerConstants.ProfileIsActiveCallers* contains the different constant values.
+- **_Client_**
 
-* ***IsActive***
-    
-    The flag indicating if the user is allowed to obtain tokens. This is expected to be assigned by the custom *IProfileService* implementation.
+  The _Client_ for which the claims are being requested.
+
+- **_Caller_**
+
+  An identifier for the context in which the claims are being requested (e.g. an identity token, an access token, or the user info endpoint. The constant _IdentityServerConstants.ProfileIsActiveCallers_ contains the different constant values.
+
+- **_IsActive_**
+  The flag indicating if the user is allowed to obtain tokens. This is expected to be assigned by the custom _IProfileService_ implementation.


### PR DESCRIPTION
When server side sessions is enabled the subject in the profile service will contain the claims of the stored session. That behavior changed in v7 but the doc wasn't updated.