### PR TITLE
Sunset quickstart "javascript applications without a backend"

### DIFF
--- a/IdentityServer/v7/docs/content/quickstarts/js_clients/_index.md
+++ b/IdentityServer/v7/docs/content/quickstarts/js_clients/_index.md
@@ -1,20 +1,20 @@
 +++
-title = "Building JavaScript client applications"
+title = "Building Browser-Based Client Applications"
 weight = 10
 chapter = true
 +++
 
 # JavaScript/SPA Client Applications
 
-When building JavaScript (or SPA) applications, there are two main styles: those
+When building browser-based or SPA applications, there are two main styles: those
 with a backend and those without.
 
 JavaScript applications **with a backend** are more secure, making it the
-preferred style. This style uses the ["Backend For Frontend"
+recommended style. This style uses the ["Backend For Frontend"
 pattern](https://blog.duendesoftware.com/posts/20210326_bff/), or "BFF" for
 short, which relies on the backend host to implement all of the security
 protocol interactions with the token server. The *Duende.BFF* library is used in
-this quickstart to easily support the BFF pattern.
+[this quickstart]({{< ref "js_with_backend.md" >}}) to easily support the BFF pattern.
 
 JavaScript applications **without a backend** need to do all the security
 protocol interactions on the client-side, including driving user authentication
@@ -22,11 +22,12 @@ and token requests, session and token management, and token storage. This leads
 to more complex JavaScript, cross-browser incompatibilities, and a considerably
 higher attack surface. Since this style inherently needs to store security
 sensitive artifacts (like tokens) in JavaScript reachable locations, this style
-is not encouraged for applications dealing with sensitive data. As the ["OAuth
-2.0 for Browser-Based Apps" IETF/OAuth working group BCP
+is not recommended. **Consequently we don't offer a quickstart for this style**.
+
+As the ["OAuth 2.0 for Browser-Based Apps" IETF/OAuth working group BCP
 document](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps)
-says 
->there is no browser API that allows to store tokens in a completely secure way.
+says:
+>there is no browser API that allows to store tokens in a completely secure way. 
 
 Additionally, modern browsers have recently added or are planning to add privacy
 features that can break some front-channel protocol interactions. See 

--- a/IdentityServer/v7/docs/content/quickstarts/js_clients/_index.md
+++ b/IdentityServer/v7/docs/content/quickstarts/js_clients/_index.md
@@ -4,19 +4,19 @@ weight = 10
 chapter = true
 +++
 
-# JavaScript/SPA Client Applications
+# Building Browser-Based Client Applications
 
-When building browser-based or SPA applications, there are two main styles: those
+When building browser-based or SPA applications using javascript, there are two main styles: those
 with a backend and those without.
 
-JavaScript applications **with a backend** are more secure, making it the
+Browser-based applications **with a backend** are more secure, making it the
 recommended style. This style uses the ["Backend For Frontend"
 pattern](https://blog.duendesoftware.com/posts/20210326_bff/), or "BFF" for
 short, which relies on the backend host to implement all of the security
 protocol interactions with the token server. The *Duende.BFF* library is used in
 [this quickstart]({{< ref "js_with_backend.md" >}}) to easily support the BFF pattern.
 
-JavaScript applications **without a backend** need to do all the security
+Browser-based applications **without a backend** need to do all the security
 protocol interactions on the client-side, including driving user authentication
 and token requests, session and token management, and token storage. This leads
 to more complex JavaScript, cross-browser incompatibilities, and a considerably

--- a/IdentityServer/v7/docs/content/quickstarts/js_clients/js_with_backend.md
+++ b/IdentityServer/v7/docs/content/quickstarts/js_clients/js_with_backend.md
@@ -1,5 +1,5 @@
 ---
-title: "JavaScript applications with a backend"
+title: "Browser-Based Applications with a BFF"
 weight: 10
 ---
 

--- a/IdentityServer/v7/docs/content/quickstarts/js_clients/js_without_backend.md
+++ b/IdentityServer/v7/docs/content/quickstarts/js_clients/js_without_backend.md
@@ -1,4 +1,5 @@
 ---
+expiryDate: 2024-09-11
 title: "JavaScript applications without a backend"
 weight: 20
 ---


### PR DESCRIPTION
- Mentioned qs is set to expired
- Modified overview document mentioning that we don't offer a quickstart for this style
- Renamed "Javascript applications with a backend" to "Browser-Based Applications with a BFF"