### PR TITLE
Add upgrade documentation for IdentityServer v7.1

### DIFF
--- a/IdentityServer/v7/docs/content/upgrades/_index.md
+++ b/IdentityServer/v7/docs/content/upgrades/_index.md
@@ -14,8 +14,8 @@ Migrations.
 ## Upgrading from version 7.0 to 7.1
 IdentityServer v7.1 includes support for **.NET 9** and many other smaller fixes and
 enhancements. There are no schema changes needed for IdentityServer 7.1. There are two changes that may require small code changes for a minority of users:
-- **IdentityModel** renamed **Duende.IdentityModel**
-- *ClientConfigurationStore* now uses *IConfigurationDbContext*
+- **IdentityModel** package renamed to **Duende.IdentityModel** which may require code updates to referenced namespaces and types.
+- *ClientConfigurationStore* now uses *IConfigurationDbContext*.
 
 ## Upgrading from version 6 to version 7
 We recommend upgrading incrementally through each minor version of the 6.x release before upgrading from

--- a/IdentityServer/v7/docs/content/upgrades/_index.md
+++ b/IdentityServer/v7/docs/content/upgrades/_index.md
@@ -11,6 +11,12 @@ changes. Some updates contain changes to the stores used by IdentityServer that 
 schema updates. If you are using our Entity Framework based stores we recommend using Entity Framework
 Migrations.
 
+## Upgrading from version 7.0 to 7.1
+IdentityServer v7.1 includes support for **.NET 9** and many other smaller fixes and
+enhancements. There are no schema changes needed for IdentityServer 7.1. There are two changes that may require small code changes for a minority of users:
+- **IdentityModel** renamed **Duende.IdentityModel**
+- *ClientConfigurationStore* now uses *IConfigurationDbContext*
+
 ## Upgrading from version 6 to version 7
 We recommend upgrading incrementally through each minor version of the 6.x release before upgrading from
 6.3 to 7.0. At each step, update the nuget package, apply database schema changes (if any), and check for

--- a/IdentityServer/v7/docs/content/upgrades/v7.0_to_v7.1.md
+++ b/IdentityServer/v7/docs/content/upgrades/v7.0_to_v7.1.md
@@ -7,7 +7,7 @@ weight: 29
 
 IdentityServer v7.1 includes support for .NET 9 and many other smaller fixes and
 enhancements. Please see our [release
-notes](https://github.com/DuendeSoftware/IdentityServer/releases/tag/7.1.0-rc.1) for
+notes](https://github.com/DuendeSoftware/IdentityServer/releases/tag/7.1.0) for
 complete details.
 
 There are no schema changes needed for IdentityServer 7.1. There are two changes that may require small code changes for a minority of users:
@@ -45,7 +45,7 @@ For example in your project file:
 would change to: 
 
 ```
-<PackageReference Include="Duende.IdentityServer" Version="7.1.0-rc.1" />
+<PackageReference Include="Duende.IdentityServer" Version="7.1.0" />
 ```
 
 ## Step 3: Breaking Changes


### PR DESCRIPTION
Updated the upgrade guide to include details for v7.1, highlighting .NET 9 support and minor required code changes. Corrected links and package references to point to the final release.