### PR TITLE
Correct references to NuGet

### DIFF
--- a/IdentityServer/v5/docs/content/apis/aspnetcore/jwt.md
+++ b/IdentityServer/v5/docs/content/apis/aspnetcore/jwt.md
@@ -38,7 +38,7 @@ public class Startup
 ```
 
 {{% notice note %}}
-On .NET Core 3.1 you need to manually reference the [System.IdentityModel.Tokens.Jwt](https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt/5.6.0) Nuget package version 5.6 to be able to check the type header.
+On .NET Core 3.1 you need to manually reference the [System.IdentityModel.Tokens.Jwt](https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt/5.6.0) NuGet package version 5.6 to be able to check the type header.
 {{% /notice %}}
 
 ## Adding audience validation

--- a/IdentityServer/v5/docs/content/bff/_index.md
+++ b/IdentityServer/v5/docs/content/bff/_index.md
@@ -11,4 +11,4 @@ The Duende.BFF (Backend for Frontend) security framework packages up guidance an
 
 Duende.BFF is part of the [IdentityServer](https://duendesoftware.com/products/identityserver) Business Edition or higher. The same [license](https://duendesoftware.com/products/identityserver#pricing) and [special offers](https://duendesoftware.com/specialoffers) apply.
 
-The source code for the BFF framework can be found [here](https://github.com/DuendeSoftware/BFF). Nuget [here](https://www.nuget.org/packages/Duende.BFF/). Samples [here]({{< ref "/samples/bff" >}}).
+The source code for the BFF framework can be found [here](https://github.com/DuendeSoftware/BFF). NuGet [here](https://www.nuget.org/packages/Duende.BFF/). Samples [here]({{< ref "/samples/bff" >}}).

--- a/IdentityServer/v5/docs/content/overview/packaging.md
+++ b/IdentityServer/v5/docs/content/overview/packaging.md
@@ -23,7 +23,7 @@ We still provide you a starting point for your modifications.
 ### Templates
 Contains templates for the dotnet CLI.
 
-* Nuget [package](https://www.nuget.org/packages/Duende.IdentityServer.Templates)
+* NuGet [package](https://www.nuget.org/packages/Duende.IdentityServer.Templates)
 * [source code](https://github.com/DuendeSoftware/IdentityServer.Templates)
 
 You can install the templates using the following command:

--- a/IdentityServer/v5/docs/content/quickstarts/1_client_credentials.md
+++ b/IdentityServer/v5/docs/content/quickstarts/1_client_credentials.md
@@ -186,7 +186,7 @@ public class IdentityController : ControllerBase
 This controller will be used later to test the authorization requirement, as well as visualize the claims identity through the eyes of the API.
 
 #### Adding a Nuget Dependency
-In order for the configuration step to work the nuget package dependency has to be added, run this command in the root directory.
+In order for the configuration step to work the NuGet package dependency has to be added, run this command in the root directory.
 
     dotnet add ./src/Api/Api.csproj package Microsoft.AspNetCore.Authentication.JwtBearer
 

--- a/IdentityServer/v5/docs/content/quickstarts/2_interactive.md
+++ b/IdentityServer/v5/docs/content/quickstarts/2_interactive.md
@@ -56,7 +56,7 @@ run from the src folder:
 We recommend using the self-host option over IIS Express. The rest of the docs assume you are using self-hosting on port 5002.
 {{% /notice %}}
 
-To add support for OpenID Connect authentication to the MVC application, you first need to add the nuget package containing the OpenID Connect handler to your project, e.g.::
+To add support for OpenID Connect authentication to the MVC application, you first need to add the NuGet package containing the OpenID Connect handler to your project, e.g.::
 
     dotnet add package Microsoft.AspNetCore.Authentication.OpenIdConnect
 
@@ -337,7 +337,7 @@ local IdentityServer by adding the */signin-google* path to your base-address (e
 The developer console will show you a client ID and secret issued by Google - you will need that in the next step.
 
 Add the Google authentication handler to the DI of the IdentityServer host.
-This is done by first adding the *Microsoft.AspNetCore.Authentication.Google* nuget package and then adding this snippet to *ConfigureServices* in *Startup*:
+This is done by first adding the *Microsoft.AspNetCore.Authentication.Google* NuGet package and then adding this snippet to *ConfigureServices* in *Startup*:
 
 ```cs
 services.AddAuthentication()

--- a/IdentityServer/v5/docs/content/quickstarts/4_ef.md
+++ b/IdentityServer/v5/docs/content/quickstarts/4_ef.md
@@ -29,7 +29,7 @@ Our EF integration library implements the required stores and services using the
 
 These contexts are suitable for any Entity Framework Core compatible relational database.
 
-You can find the extension methods to register them in your IdentityServer in the *Duende.IdentityServer.EntityFramework* nuget package, which we will add to the *IdentityServer* project now:
+You can find the extension methods to register them in your IdentityServer in the *Duende.IdentityServer.EntityFramework* NuGet package, which we will add to the *IdentityServer* project now:
 
     dotnet add package Duende.IdentityServer.EntityFramework
 
@@ -37,7 +37,7 @@ You can find the extension methods to register them in your IdentityServer in th
 For this quickstart, we will use Sqlite as the database provider.
 Of course, given EntityFramework Core's flexibility, you can adjust this quickstart to use any EF supported provider.
 
-To add Sqlite support to our IdentityServer project, you’ll need the following nuget package:
+To add Sqlite support to our IdentityServer project, you’ll need the following NuGet package:
 
 ```
 dotnet add package Microsoft.EntityFrameworkCore.Sqlite
@@ -91,7 +91,7 @@ This is necessary since the host project is in a different assembly than the one
 ### Adding Migrations
 Once the IdentityServer has been configured to use Entity Framework, we’ll need to generate some migrations.
 
-To create migrations, you will need to install the Entity Framework Core CLI on your machine and the *Microsoft.EntityFrameworkCore.Design* nuget package in IdentityServer:
+To create migrations, you will need to install the Entity Framework Core CLI on your machine and the *Microsoft.EntityFrameworkCore.Design* NuGet package in IdentityServer:
 
     dotnet tool install --global dotnet-ef
     dotnet add package Microsoft.EntityFrameworkCore.Design

--- a/IdentityServer/v5/docs/content/quickstarts/js_clients/js_with_backend.md
+++ b/IdentityServer/v5/docs/content/quickstarts/js_clients/js_with_backend.md
@@ -37,7 +37,7 @@ dotnet sln add .\src\JavaScriptClient\JavaScriptClient.csproj
 
 ### Add additional NuGet packages
 
-To add BFF and OIDC support to the *JavaScriptClient* project, you’ll need the following nuget packages:
+To add BFF and OIDC support to the *JavaScriptClient* project, you’ll need the following NuGet packages:
 
 ```
 dotnet add package Microsoft.AspNetCore.Authentication.OpenIdConnect

--- a/IdentityServer/v6/docs/content/apis/aspnetcore/jwt.md
+++ b/IdentityServer/v6/docs/content/apis/aspnetcore/jwt.md
@@ -38,7 +38,7 @@ public class Startup
 ```
 
 {{% notice note %}}
-On .NET Core 3.1 you need to manually reference the [System.IdentityModel.Tokens.Jwt](https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt/5.6.0) Nuget package version 5.6 to be able to check the type header.
+On .NET Core 3.1 you need to manually reference the [System.IdentityModel.Tokens.Jwt](https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt/5.6.0) NuGet package version 5.6 to be able to check the type header.
 {{% /notice %}}
 
 ## Adding audience validation

--- a/IdentityServer/v6/docs/content/configuration/_index.md
+++ b/IdentityServer/v6/docs/content/configuration/_index.md
@@ -9,7 +9,7 @@ weight: 96
 The Configuration API is a collection of endpoints that allow for management and
 configuration of an IdentityServer implementation. The Configuration API can be
 hosted either separately or within the IdentityServer implementation, and is
-distributed through the separate [Duende.IdentityServer.Configuration nuget
+distributed through the separate [Duende.IdentityServer.Configuration NuGet
 package](https://www.nuget.org/packages/Duende.IdentityServer.Configuration).
 
 In this initial release, the Configuration API supports the [Dynamic Client

--- a/IdentityServer/v6/docs/content/overview/packaging.md
+++ b/IdentityServer/v6/docs/content/overview/packaging.md
@@ -21,7 +21,7 @@ We still provide you a starting point for your modifications.
 ### Templates
 Contains templates for the dotnet CLI.
 
-* Nuget [package](https://www.nuget.org/packages/Duende.IdentityServer.Templates)
+* NuGet [package](https://www.nuget.org/packages/Duende.IdentityServer.Templates)
 * [source code](https://github.com/DuendeSoftware/IdentityServer.Templates)
 
 You can install the templates using the following command:

--- a/IdentityServer/v6/docs/content/quickstarts/1_client_credentials.md
+++ b/IdentityServer/v6/docs/content/quickstarts/1_client_credentials.md
@@ -63,7 +63,7 @@ dotnet new isempty -n IdentityServer
 
 This will create the following files within a new *src/IdentityServer* directory:
 
-* *IdentityServer.csproj* - project file with the IdentityServer nuget package
+* *IdentityServer.csproj* - project file with the IdentityServer NuGet package
   added
 * *Properties/launchSettings.json* file - launch profile
 * *appsettings.json* - run time settings
@@ -243,7 +243,7 @@ dotnet sln add ./src/Api/Api.csproj
 Now you will add JWT Bearer Authentication to the API's ASP.NET pipeline. The
 goal is to authorize calls to your API using tokens issued by the IdentityServer
 project. To that end, you will add authentication middleware to the pipeline
-from the *Microsoft.AspNetCore.Authentication.JwtBearer* nuget package. This
+from the *Microsoft.AspNetCore.Authentication.JwtBearer* NuGet package. This
 middleware will
 * Find and parse a JWT sent with incoming requests as an *Authorization: Bearer*
   header.
@@ -347,7 +347,7 @@ cd ..
 dotnet sln add ./src/Client/Client.csproj
 ```
 
-### Add the IdentityModel nuget package
+### Add the IdentityModel NuGet package
 The token endpoint at IdentityServer implements the OAuth protocol, and you
 could use raw HTTP to access it. However, we have a client library called
 IdentityModel that encapsulates the protocol interaction in an easy to use API.

--- a/IdentityServer/v6/docs/content/quickstarts/2_interactive.md
+++ b/IdentityServer/v6/docs/content/quickstarts/2_interactive.md
@@ -525,7 +525,7 @@ other authentication providers
 
 #### Add Google support
 To use Google for authentication, you need to:
-- Add the *Microsoft.AspNetCore.Authentication.Google* nuget package to
+- Add the *Microsoft.AspNetCore.Authentication.Google* NuGet package to
   the IdentityServer project.
 - Register with Google and set up a client.
 - Store the client id and secret securely with *dotnet user-secrets*.

--- a/IdentityServer/v6/docs/content/upgrades/v6.2_to_v6.3.md
+++ b/IdentityServer/v6/docs/content/upgrades/v6.2_to_v6.3.md
@@ -9,7 +9,7 @@ This upgrade guide covers upgrading from Duende IdentityServer v6.2 to v6.3 ([re
 Duende IdentityServer 6.3 adds: 
 * [Support]({{< ref "/tokens/pop/dpop" >}}) for [OAuth 2.0 Demonstrating Proof-of-Possession at the Application Layer (DPoP) ](https://datatracker.ietf.org/doc/draft-ietf-oauth-dpop/), a new OAuth specification for sender-constraining refresh tokens and access tokens.
 
-* A new [Configuration API]({{< ref "/configuration" >}}) distributed through the separate *Duende.IdentityServer.Configuration* nuget package that supports the [OAuth](https://datatracker.ietf.org/doc/rfc7591/) and [OIDC](https://openid.net/specs/openid-connect-registration-1_0.html) Dynamic Client Registration specifications.
+* A new [Configuration API]({{< ref "/configuration" >}}) distributed through the separate *Duende.IdentityServer.Configuration* NuGet package that supports the [OAuth](https://datatracker.ietf.org/doc/rfc7591/) and [OIDC](https://openid.net/specs/openid-connect-registration-1_0.html) Dynamic Client Registration specifications.
 
 * Support for [3rd party initiated login](https://openid.net/specs/openid-connect-core-1_0.html#ThirdPartyInitiatedLogin) through the new client configuration property *InitiateLoginUri*. This is typically used to create a [client application portal]({{< ref "/ui/portal" >}}) page within an IdentityServer host.
 

--- a/IdentityServer/v7/docs/content/bff/session/server_side_sessions.md
+++ b/IdentityServer/v7/docs/content/bff/session/server_side_sessions.md
@@ -24,7 +24,7 @@ The default implementation stores the session in-memory. This is useful for test
 
 ## Using Entity Framework for the Server-side Session Store
 
-To use the EF session store, install the *Duende.BFF.EntityFramework* nuget package and register it by calling *AddEntityFrameworkServerSideSessions*, like this:
+To use the EF session store, install the *Duende.BFF.EntityFramework* NuGet package and register it by calling *AddEntityFrameworkServerSideSessions*, like this:
 
 ```csharp
 var cn = _configuration.GetConnectionString("db");

--- a/IdentityServer/v7/docs/content/configuration/_index.md
+++ b/IdentityServer/v7/docs/content/configuration/_index.md
@@ -9,7 +9,7 @@ weight: 96
 The Configuration API is a collection of endpoints that allow for management and
 configuration of an IdentityServer implementation. The Configuration API can be
 hosted either separately or within the IdentityServer implementation, and is
-distributed through the separate [Duende.IdentityServer.Configuration nuget
+distributed through the separate [Duende.IdentityServer.Configuration NuGet
 package](https://www.nuget.org/packages/Duende.IdentityServer.Configuration).
 
 In this initial release, the Configuration API supports the [Dynamic Client

--- a/IdentityServer/v7/docs/content/overview/packaging.md
+++ b/IdentityServer/v7/docs/content/overview/packaging.md
@@ -21,7 +21,7 @@ We still provide you a starting point for your modifications.
 ### Templates
 Contains templates for the dotnet CLI.
 
-* Nuget [package](https://www.nuget.org/packages/Duende.IdentityServer.Templates)
+* NuGet [package](https://www.nuget.org/packages/Duende.IdentityServer.Templates)
 * [source code](https://github.com/DuendeSoftware/IdentityServer.Templates)
 
 You can install the templates using the following command:

--- a/IdentityServer/v7/docs/content/overview/security.md
+++ b/IdentityServer/v7/docs/content/overview/security.md
@@ -104,7 +104,7 @@ Then append that PEM to the certificate bundle at */usr/share/dotnet/sdk/8.0.303
 ```sh
 cat sectigo.pem >> /usr/share/dotnet/sdk/8.0.303/trustedroots/codesignctl.pem
 ```
-After that, NuGet packages signed by Duende can be successfully verified, even if they are not distributed by nuget.org:
+After that, NuGet packages signed by Duende can be successfully verified, even if they are not distributed by NuGet.org:
 ```sh
 dotnet nuget verify Duende.IdentityServer.7.0.x.nupkg
 ```

--- a/IdentityServer/v7/docs/content/quickstarts/1_client_credentials.md
+++ b/IdentityServer/v7/docs/content/quickstarts/1_client_credentials.md
@@ -73,7 +73,7 @@ dotnet new isempty -n IdentityServer
 
 This will create the following files within a new *src/IdentityServer* directory:
 
-- *IdentityServer.csproj* - project file with the IdentityServer nuget package
+- *IdentityServer.csproj* - project file with the IdentityServer NuGet package
   added
 - *Properties/launchSettings.json* file - launch profile
 - *appsettings.json* - run time settings
@@ -260,7 +260,7 @@ dotnet sln add ./src/Api
 Now you will add JWT Bearer Authentication to the API's ASP.NET pipeline. The
 goal is to authorize calls to your API using tokens issued by the IdentityServer
 project. To that end, you will add authentication middleware to the pipeline
-from the *Microsoft.AspNetCore.Authentication.JwtBearer* nuget package. This
+from the *Microsoft.AspNetCore.Authentication.JwtBearer* NuGet package. This
 middleware will:
 
 - Find and parse a JWT sent with incoming requests as an *Authorization: Bearer*
@@ -349,7 +349,7 @@ cd ..
 dotnet sln add ./src/Client
 ```
 
-### Add the IdentityModel nuget package
+### Add the IdentityModel NuGet package
 
 The token endpoint at IdentityServer implements the OAuth protocol, and you
 could use raw HTTP to access it. However, we have a client library called

--- a/IdentityServer/v7/docs/content/quickstarts/2_interactive.md
+++ b/IdentityServer/v7/docs/content/quickstarts/2_interactive.md
@@ -528,7 +528,7 @@ other authentication providers
 
 #### Add Google support
 To use Google for authentication, you need to:
-- Add the *Microsoft.AspNetCore.Authentication.Google* nuget package to
+- Add the *Microsoft.AspNetCore.Authentication.Google* NuGet package to
   the IdentityServer project.
 - Register with Google and set up a client.
 - Store the client id and secret securely with *dotnet user-secrets*.

--- a/IdentityServer/v7/docs/content/upgrades/_index.md
+++ b/IdentityServer/v7/docs/content/upgrades/_index.md
@@ -13,7 +13,7 @@ Migrations.
 
 ## Upgrading from version 6 to version 7
 We recommend upgrading incrementally through each minor version of the 6.x release before upgrading from
-6.3 to 7.0. At each step, update the nuget package, apply database schema changes (if any), and check for
+6.3 to 7.0. At each step, update the NuGet package, apply database schema changes (if any), and check for
 breaking changes that affect your implementation.
 
 #### Upgrading from version 6.0

--- a/IdentityServer/v7/docs/content/upgrades/v6.2_to_v6.3.md
+++ b/IdentityServer/v7/docs/content/upgrades/v6.2_to_v6.3.md
@@ -9,7 +9,7 @@ This upgrade guide covers upgrading from Duende IdentityServer v6.2 to v6.3 ([re
 Duende IdentityServer 6.3 adds: 
 * [Support]({{< ref "/tokens/pop/dpop" >}}) for [OAuth 2.0 Demonstrating Proof-of-Possession at the Application Layer (DPoP) ](https://datatracker.ietf.org/doc/draft-ietf-oauth-dpop/), a new OAuth specification for sender-constraining refresh tokens and access tokens.
 
-* A new [Configuration API]({{< ref "/configuration" >}}) distributed through the separate *Duende.IdentityServer.Configuration* nuget package that supports the [OAuth](https://datatracker.ietf.org/doc/rfc7591/) and [OIDC](https://openid.net/specs/openid-connect-registration-1_0.html) Dynamic Client Registration specifications.
+* A new [Configuration API]({{< ref "/configuration" >}}) distributed through the separate *Duende.IdentityServer.Configuration* NuGet package that supports the [OAuth](https://datatracker.ietf.org/doc/rfc7591/) and [OIDC](https://openid.net/specs/openid-connect-registration-1_0.html) Dynamic Client Registration specifications.
 
 * Support for [3rd party initiated login](https://openid.net/specs/openid-connect-core-1_0.html#ThirdPartyInitiatedLogin) through the new client configuration property *InitiateLoginUri*. This is typically used to create a [client application portal]({{< ref "/ui/portal" >}}) page within an IdentityServer host.
 


### PR DESCRIPTION
Very much nit-picking, but wanted to correct the writing of "NuGet" everywhere in docs.