### PR TITLE
Missing brackets fixed in docs

### DIFF
--- a/IdentityServer/v6/docs/content/apis/aspnetcore/authorization.md
+++ b/IdentityServer/v6/docs/content/apis/aspnetcore/authorization.md
@@ -27,7 +27,7 @@ public void ConfigureServices(IServiceCollection services)
     services.AddAuthorization(options =>
     {
         options.AddPolicy("read_access", policy =>
-            policy.RequireClaim("scope", "read");
+            policy.RequireClaim("scope", "read"));
     });
 }
 ```

--- a/IdentityServer/v7/docs/content/apis/aspnetcore/authorization.md
+++ b/IdentityServer/v7/docs/content/apis/aspnetcore/authorization.md
@@ -25,7 +25,7 @@ With this approach, you would first turn the claim requirement(s) into a named p
 builder.Services.AddAuthorization(options =>
 {
     options.AddPolicy("read_access", policy =>
-        policy.RequireClaim("scope", "read");
+        policy.RequireClaim("scope", "read"));
 });
 ```
 


### PR DESCRIPTION
Added missing brackets in documentation:
- https://docs.duendesoftware.com/identityserver/v7/apis/aspnetcore/authorization/
- https://docs.duendesoftware.com/identityserver/v6/apis/aspnetcore/authorization/