### PR TITLE
Re-add v5 build to reduce 404's in Google Search console

### DIFF
--- a/IdentityServer/v5/docs/content/upgrades/is4_v3_to_dis_v5.md
+++ b/IdentityServer/v5/docs/content/upgrades/is4_v3_to_dis_v5.md
@@ -137,4 +137,4 @@ At this point, you should be able to query your migrated database and see your d
 ## Step 4: Move onto the upgrade guide for Duende IdentityServer v5
 
 Once your project has been updated to IdentityServer4 v4, then you can work through the guide to update from IdentityServer4 v4 to Duende IdentityServer v5 (which should be far easier).
-Here is the [link to the next upgrade guide]({{< ref "/is4_v4_to_dis_v5" >}}).
+Here is the [link to the next upgrade guide]({{< ref "is4_v4_to_dis_v5" >}}).

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,9 @@
 set -e
 
+pushd ./IdentityServer/v5/docs
+hugo -d ../../../root/identityserver/v5
+popd
+
 pushd ./IdentityServer/v6/docs
 hugo -d ../../../root/identityserver/v6
 popd

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "v7": "hugo server --port 1313 --navigateToChanged --source IdentityServer/v7/docs",
     "v6": "hugo server --port 1312 --navigateToChanged --source IdentityServer/v6/docs",
+    "v5": "hugo server --port 1311 --navigateToChanged --source IdentityServer/v5/docs",
     "foss": "hugo server --port 1314 --navigateToChanged --source FOSS"
   },
   "description": "Documentation for Duende Software products",


### PR DESCRIPTION
Still need a way to reduce them in ranking, but at least this should fix a lot of 404s of pages that were not deployed with v5 before