### PR TITLE
Add documentation for the Token Creation Service

### DIFF
--- a/IdentityServer/v7/docs/content/reference/services/token_creation_service.md
+++ b/IdentityServer/v7/docs/content/reference/services/token_creation_service.md
@@ -23,9 +23,10 @@ public interface ITokenCreationService
 
 The Token creation service takes the *Token* model and converts it into
 a JWT. During the JWT creation, you have one last opportunity to
-modify the *Token* by adding, removing, or altering property values. Everyday use cases
+modify the *Token* by adding, removing, or altering property values. Common use cases
 for implementing the *ITokenCreationService* include modifying claims, audiences, and more
-from a secondary data source, such as a profile service, database, or third-party service.
+from a secondary data source, such as a profile service, database, or third-party service
+when other approaches are not an option.
 
 Note that there are better places within IdentityServer's infrastructure to add
 additional claims, such as *IClaimService*, *ITokenService*, and [*IProfileService*]({{< ref "/reference/services/profile_service.md" >}}). We recommend investigating

--- a/IdentityServer/v7/docs/content/reference/services/token_creation_service.md
+++ b/IdentityServer/v7/docs/content/reference/services/token_creation_service.md
@@ -35,7 +35,7 @@ If, after research, you have still decided to implement *ITokenCreationService*,
 inherit and override methods on *DefaultTokenCreationService*, specifically the *CreatePayloadAsync* method.
 
 {{% notice warning %}}
-Do not overload your tokens with large amounts of data as it can lead to large JWTs and adversely affect system performance.
+Do not overload your tokens with large amounts of data, as it can lead to large JWTs and adversely affect system performance.
 {{% /notice %}}
 
 ```csharp

--- a/IdentityServer/v7/docs/content/reference/services/token_creation_service.md
+++ b/IdentityServer/v7/docs/content/reference/services/token_creation_service.md
@@ -21,13 +21,17 @@ public interface ITokenCreationService
 }
 ```
 
-Token creation involves taking the *Token* argument and converting it into
-a JWT string. During the JWT creation, you have an opportunity to
-change the *Token* by adding, removing, or altering property values.
+The Token creation service involves taking the *Token* model and converting it into
+a JWT. During the JWT creation, you have one last opportunity to
+modify the *Token* by adding, removing, or altering property values. Everyday use cases
+for implementing the *ITokenCreationService* include modifying claims, audiences, and more
+from a secondary data source, such as a profile service, database, or third-party service.
 
-Common use cases for implementing the *ITokenCreationService* include adding custom claims from a secondary data source, such a profile service, database, or third-party service.
+Note that there are better places within IdentityServer's infrastructure to add
+additional claims, such as *IClaimService*, *ITokenService*, and *IProfileService*. We recommend investigating
+whether overriding those interfaces would be sufficient before implementing *ITokenCreationService*.
 
-While you could implement an *ITokenCreationService* interface, we recommend you 
+If, after research, you have still decided to implement *ITokenCreationService*, we recommend you
 inherit and override methods on *DefaultTokenCreationService*, specifically the *CreatePayloadAsync* method.
 
 {{% notice warning %}}
@@ -53,7 +57,7 @@ public class CustomTokenCreationService : DefaultTokenCreationService
 }
 ```
 
-After creating your new implementation, be sure to register the type in your application's service collection.
+After creating your new implementation, register the type in your application's service collection.
 
 ```csharp
 builder.Services.AddTransient<ITokenCreationService, CustomTokenCreationService>();

--- a/IdentityServer/v7/docs/content/reference/services/token_creation_service.md
+++ b/IdentityServer/v7/docs/content/reference/services/token_creation_service.md
@@ -33,7 +33,7 @@ whether overriding those interfaces would be enough before implementing *ITokenC
 
 You can think of each of the services as providing the following functionality:
 
-- *ITokenCreationService* : Token Serialization into a JWT
+- *ITokenCreationService* : Serialization of the *Token* model into a JWT
 - *ITokenService*: Building the Token using the data model
 - *IClaimsService*: Customizing claims on the Token
 - *IProfileService*: User-centric profile data used in the Token and UserInfo endpoint

--- a/IdentityServer/v7/docs/content/reference/services/token_creation_service.md
+++ b/IdentityServer/v7/docs/content/reference/services/token_creation_service.md
@@ -23,7 +23,7 @@ public interface ITokenCreationService
 
 Token creation involves taking the *Token* argument and converting it into
 a JWT string. During the JWT creation, you have an opportunity to
-change the *Token* by adding, removing, or altering properties values.
+change the *Token* by adding, removing, or altering property values.
 
 Common use cases for implementing the *ITokenCreationService* include adding custom claims from a secondary data source, such a profile service, database, or third-party service.
 

--- a/IdentityServer/v7/docs/content/reference/services/token_creation_service.md
+++ b/IdentityServer/v7/docs/content/reference/services/token_creation_service.md
@@ -28,8 +28,16 @@ for implementing the *ITokenCreationService* include modifying claims, audiences
 from a secondary data source, such as a profile service, database, or third-party service.
 
 Note that there are better places within IdentityServer's infrastructure to add
-additional claims, such as *IClaimService*, *ITokenService*, and *IProfileService*. We recommend investigating
-whether overriding those interfaces would be sufficient before implementing *ITokenCreationService*.
+additional claims, such as *IClaimService*, *ITokenService*, and [*IProfileService*]({{< ref "/reference/services/profile_service.md" >}}). We recommend investigating
+whether overriding those interfaces would be enough before implementing *ITokenCreationService*.
+
+You can think of each of the services as providing the following functionality:
+
+- *ITokenCreationService* : Token Serialization into a JWT
+- *ITokenService*: Building the Token using the data model
+- *IClaimsService*: Customizing claims on the Token
+- *IProfileService*: User-centric profile data used in the Token and UserInfo endpoint
+
 
 If, after research, you have still decided to implement *ITokenCreationService*, we recommend you
 inherit and override methods on *DefaultTokenCreationService*, specifically the *CreatePayloadAsync* method.

--- a/IdentityServer/v7/docs/content/reference/services/token_creation_service.md
+++ b/IdentityServer/v7/docs/content/reference/services/token_creation_service.md
@@ -21,7 +21,7 @@ public interface ITokenCreationService
 }
 ```
 
-The Token creation service involves taking the *Token* model and converting it into
+The Token creation service takes the *Token* model and converts it into
 a JWT. During the JWT creation, you have one last opportunity to
 modify the *Token* by adding, removing, or altering property values. Everyday use cases
 for implementing the *ITokenCreationService* include modifying claims, audiences, and more

--- a/IdentityServer/v7/docs/content/reference/services/token_creation_service.md
+++ b/IdentityServer/v7/docs/content/reference/services/token_creation_service.md
@@ -1,0 +1,62 @@
+---
+title: "Token Creation Service"
+weight: 50
+---
+
+IdentityServer uses an *ITokenCreationService* which is responsible for the creation
+of tokens, with the default implementation of *DefaultTokenCreationService*.
+
+```csharp
+/// <summary>
+/// Logic for creating security tokens
+/// </summary>
+public interface ITokenCreationService
+{
+    /// <summary>
+    /// Creates a token.
+    /// </summary>
+    /// <param name="token">The token description.</param>
+    /// <returns>A protected and serialized security token</returns>
+    Task<string> CreateTokenAsync(Token token);
+}
+```
+
+Token creation involves taking the *Token* argument and converting it into
+a JWT string. During the JWT creation, you have an opportunity to
+change the *Token* by adding, removing, or altering properties values.
+
+Common use cases for implementing the *ITokenCreationService* include adding custom claims from a secondary data source, such a profile service, database, or third-party service.
+
+While you could implement an *ITokenCreationService* interface, we recommend you 
+inherit and override methods on *DefaultTokenCreationService*, specifically the *CreatePayloadAsync* method.
+
+{{% notice warning %}}
+Do not overload your tokens with large amounts of data as it can lead to large JWTs and adversely affect system performance.
+{{% /notice %}}
+
+```csharp
+public class CustomTokenCreationService : DefaultTokenCreationService
+{
+    public CustomTokenCreationService(IClock clock, 
+        IKeyMaterialService keys,
+        IdentityServerOptions options,
+        ILogger<DefaultTokenCreationService> logger) 
+        : base(clock, keys, options, logger)
+    {
+    }
+
+    protected override Task<string> CreatePayloadAsync(Token token)
+    {
+        token.Audiences.Add("custom1");
+        return base.CreatePayloadAsync(token);
+    }
+}
+```
+
+After creating your new implementation, be sure to register the type in your application's service collection.
+
+```csharp
+builder.Services.AddTransient<ITokenCreationService, CustomTokenCreationService>();
+```
+
+IdentityServer will begin to use your new implementation in place of *DefaultTokenCreationService*.

--- a/IdentityServer/v7/docs/content/reference/services/token_creation_service.md
+++ b/IdentityServer/v7/docs/content/reference/services/token_creation_service.md
@@ -34,7 +34,7 @@ whether overriding those interfaces would be enough before implementing *ITokenC
 You can think of each of the services as providing the following functionality:
 
 - *ITokenCreationService* : Serialization of the *Token* model into a JWT
-- *ITokenService*: Building the Token using the data model
+- *ITokenService*: Building the *Token* model
 - *IClaimsService*: Customizing claims on the Token
 - *IProfileService*: User-centric profile data used in the Token and UserInfo endpoint
 


### PR DESCRIPTION
Introduced a new reference page explaining the ITokenCreationService in IdentityServer. It details the default implementation, custom use cases, and recommendations for extending the service. This serves as a guide for customizing token creation logic in IdentityServer.

#253