### PR TITLE
Add standardized newer content warning across versions

### DIFF
--- a/IdentityServer/v5/docs/config.toml
+++ b/IdentityServer/v5/docs/config.toml
@@ -11,3 +11,12 @@ home = [ "HTML", "RSS", "JSON"]
 editURL = "https://github.com/DuendeSoftware/docs.duendesoftware.com/edit/main/IdentityServer/v5/docs/content/"
 qs_base = "https://github.com/DuendeSoftware/Samples/tree/main/IdentityServer/v5/Quickstarts"
 samples_base = "https://github.com/DuendeSoftware/Samples/tree/main/IdentityServer/v5"
+
+[params.newContent]
+enabled = true
+url = "https://docs.duendesoftware.com/identityserver/v7/"
+replace = "/v5/"
+with = "/v7/"
+currentVersion = "5.x"
+newerVersion = "7.x"
+outOfSupportSince = "December 13, 2022"

--- a/IdentityServer/v5/docs/content/bff/extensibility/proxy.md
+++ b/IdentityServer/v5/docs/content/bff/extensibility/proxy.md
@@ -2,6 +2,7 @@
 title: "Reverse Proxy"
 date: 2020-09-10T08:22:12+02:00
 weight: 40
+newContentUrl: "https://docs.duendesoftware.com/identityserver/v7/bff/apis/yarp/"
 ---
 
 You can customize the proxy behavior in two ways

--- a/IdentityServer/v5/docs/content/quickstarts/js_clients/js_without_backend.md
+++ b/IdentityServer/v5/docs/content/quickstarts/js_clients/js_without_backend.md
@@ -1,6 +1,7 @@
 ---
 title: "JavaScript applications without a backend"
 weight: 2
+newContentUrl: "https://docs.duendesoftware.com/identityserver/v7/quickstarts/js_clients/"
 ---
 
 {{% notice note %}}

--- a/IdentityServer/v5/docs/content/samples/extension_grants.md
+++ b/IdentityServer/v5/docs/content/samples/extension_grants.md
@@ -2,6 +2,7 @@
 title: "Extension Grants and Token Exchange"
 date: 2020-09-10T08:22:12+02:00
 weight: 50
+newContentUrl: "https://docs.duendesoftware.com/identityserver/v7/tokens/extension_grants/"
 ---
 
 [link to source code]({{< param samples_base >}}/TokenExchange)

--- a/IdentityServer/v5/docs/content/samples/pat.md
+++ b/IdentityServer/v5/docs/content/samples/pat.md
@@ -2,6 +2,7 @@
 title: "Personal Access Tokens (PAT)"
 date: 2020-09-10T08:22:12+02:00
 weight: 50
+newContentUrl: "https://docs.duendesoftware.com/identityserver/v7/samples/tokens/"
 ---
 
 [link to source code]({{< param samples_base >}}/PAT)

--- a/IdentityServer/v5/docs/content/samples/windowsauth.md
+++ b/IdentityServer/v5/docs/content/samples/windowsauth.md
@@ -1,6 +1,7 @@
 ---
 title: "Windows Authentication"
 weight: 22
+newContentUrl: "https://docs.duendesoftware.com/identityserver/v7/samples/"
 ---
 
 This solution contains samples when using [Windows Authentication]({{< ref "/ui/login/windows" >}}).

--- a/IdentityServer/v5/docs/content/upgrades/is4_v3_to_dis_v5.md
+++ b/IdentityServer/v5/docs/content/upgrades/is4_v3_to_dis_v5.md
@@ -1,6 +1,7 @@
 ---
 title: "IdentityServer4 v3.1 to Duende IdentityServer v5"
 weight: 150
+newContentUrl: "https://docs.duendesoftware.com/identityserver/v7/upgrades/"
 ---
 
 This upgrade guide covers upgrading from IdentityServer4 v3.1.x to Duende IdentityServer v5.

--- a/IdentityServer/v5/docs/content/upgrades/is4_v4_to_dis_v5.md
+++ b/IdentityServer/v5/docs/content/upgrades/is4_v4_to_dis_v5.md
@@ -1,6 +1,7 @@
 ---
 title: "IdentityServer4 v4.1 to Duende IdentityServer v5"
 weight: 100
+newContentUrl: "https://docs.duendesoftware.com/identityserver/v7/upgrades/"
 ---
 
 This upgrade guide covers upgrading from IdentityServer4 v4.1.x to Duende IdentityServer v5.

--- a/IdentityServer/v5/docs/themes/hugo-theme-learn/layouts/partials/header.html
+++ b/IdentityServer/v5/docs/themes/hugo-theme-learn/layouts/partials/header.html
@@ -116,13 +116,7 @@
         <div id="head-tags">
         {{ partial "tags.html" . }}
         </div>
-
-        <div class="notices warning">
-          <p>Version 5.x has been out of support since December 13, 2022, and this
-            corresponding section of the documentation is no longer maintained. We
-            strongly recommend upgrading to a <a class="highlight" href="https://docs.duendesoftware.com/identityserver/v7">supported version.</a></p>
-        </div>
-
+        {{ partial "newer-content-warning.html" . }}
         {{ if .Params.chapter }}
           <div id="chapter">
         {{ end }}

--- a/IdentityServer/v5/docs/themes/hugo-theme-learn/layouts/partials/newer-content-warning.html
+++ b/IdentityServer/v5/docs/themes/hugo-theme-learn/layouts/partials/newer-content-warning.html
@@ -1,0 +1,12 @@
+{{ if .Site.Params.NewContent.Enabled }}
+<div class="notices warning">
+  {{ $url := replace .Permalink .Site.Params.NewContent.Replace .Site.Params.NewContent.With }}
+  {{ if .Page.Params.NewContentUrl }}
+  {{ $url = .Page.Params.NewContentUrl }}
+  {{ end }}
+  <p><a class="highlight" href="https://duendesoftware.com/products/support">Version {{ .Site.Params.NewContent.CurrentVersion }} has been <span class="hljs-strong">out of support since {{ .Site.Params.NewContent.OutOfSupportSince }}</span></a>, and this
+    corresponding section of the documentation is no longer maintained. We strongly recommend you
+    <a class="highlight hljs-strong" href="{{ .Site.Params.NewContent.Url }}">upgrade to the latest supported version of {{ .Site.Params.NewContent.NewerVersion }}</a>
+    and <a class="highlight hljs-strong" href="{{ $url }}">read the latest version of this documentation.</a></p>
+</div>
+{{ end }}

--- a/IdentityServer/v6/docs/config.toml
+++ b/IdentityServer/v6/docs/config.toml
@@ -14,3 +14,12 @@ samples_base = "https://github.com/DuendeSoftware/Samples/tree/main/IdentityServ
 
 [markup.goldmark.renderer]
 unsafe= true
+
+[params.newContent]
+enabled = true
+url = "https://docs.duendesoftware.com/identityserver/v7/"
+replace = "/v6/"
+with = "/v7/"
+currentVersion = "6.x"
+newerVersion = "7.x"
+outOfSupportSince = "May 14, 2024"

--- a/IdentityServer/v6/docs/content/_index.md
+++ b/IdentityServer/v6/docs/content/_index.md
@@ -6,11 +6,3 @@ weight: 1
 # Duende IdentityServer v6 Documentation
 The most flexible & standards-compliant OpenID Connect and OAuth 2.0 framework for ASP.NET Core.
 
-{{% notice info %}}
-This is the version 6 documention. Version 6.x is compatible with .NET 6 and .NET 7. Please use [v7.x](https://docs.duendesoftware.com/identityserver/v7) for .NET 8.
-{{% /notice %}}
-
-{{% notice note %}}
-Version 6.x is supported until November 12, 2024 when .NET 6 support ends.
-{{% /notice %}}
-

--- a/IdentityServer/v6/docs/content/quickstarts/js_clients/js_with_backend.md
+++ b/IdentityServer/v6/docs/content/quickstarts/js_clients/js_with_backend.md
@@ -1,6 +1,7 @@
 ---
 title: "JavaScript applications with a backend"
 weight: 10
+
 ---
 
 {{% notice note %}}

--- a/IdentityServer/v6/docs/content/quickstarts/js_clients/js_without_backend.md
+++ b/IdentityServer/v6/docs/content/quickstarts/js_clients/js_without_backend.md
@@ -1,6 +1,7 @@
 ---
 title: "JavaScript applications without a backend"
 weight: 20
+newContentUrl: "https://docs.duendesoftware.com/identityserver/v7/quickstarts/js_clients/"
 ---
 
 {{% notice note %}}

--- a/IdentityServer/v6/docs/themes/hugo-theme-learn/layouts/partials/header.html
+++ b/IdentityServer/v6/docs/themes/hugo-theme-learn/layouts/partials/header.html
@@ -117,6 +117,7 @@
         <div id="head-tags">
         {{ partial "tags.html" . }}
         </div>
+        {{ partial "newer-content-warning.html" . }}
         {{ if .Params.chapter }}
           <div id="chapter">
         {{ end }}

--- a/IdentityServer/v6/docs/themes/hugo-theme-learn/layouts/partials/newer-content-warning.html
+++ b/IdentityServer/v6/docs/themes/hugo-theme-learn/layouts/partials/newer-content-warning.html
@@ -1,0 +1,12 @@
+{{ if .Site.Params.NewContent.Enabled }}
+<div class="notices warning">
+  {{ $url := replace .Permalink .Site.Params.NewContent.Replace .Site.Params.NewContent.With }}
+  {{ if .Page.Params.NewContentUrl }}
+  {{ $url = .Page.Params.NewContentUrl }}
+  {{ end }}
+  <p><a class="highlight" href="https://duendesoftware.com/products/support">Version {{ .Site.Params.NewContent.CurrentVersion }} has been <span class="hljs-strong">out of support since {{ .Site.Params.NewContent.OutOfSupportSince }}</span></a>, and this
+    corresponding section of the documentation is no longer maintained. We strongly recommend you
+    <a class="highlight hljs-strong" href="{{ .Site.Params.NewContent.Url }}">upgrade to the latest supported version of {{ .Site.Params.NewContent.NewerVersion }}</a>
+    and <a class="highlight hljs-strong" href="{{ $url }}">read the latest version of this documentation.</a></p>
+</div>
+{{ end }}

--- a/IdentityServer/v7/docs/config.toml
+++ b/IdentityServer/v7/docs/config.toml
@@ -11,3 +11,6 @@ home = [ "HTML", "RSS", "JSON"]
 editURL = "https://github.com/DuendeSoftware/docs.duendesoftware.com/edit/main/IdentityServer/v7/docs/content/"
 qs_base = "https://github.com/DuendeSoftware/Samples/tree/main/IdentityServer/v7/Quickstarts"
 samples_base = "https://github.com/DuendeSoftware/Samples/tree/main/IdentityServer/v7"
+
+[params.newContent]
+enabled = false

--- a/IdentityServer/v7/docs/content/_index.md
+++ b/IdentityServer/v7/docs/content/_index.md
@@ -5,7 +5,3 @@ weight: 1
 
 # Duende IdentityServer v7 Documentation
 The most flexible & standards-compliant OpenID Connect and OAuth 2.0 framework for ASP.NET Core.
-
-{{% notice note %}}
-This is the documentation for version 7.x. You can find the v6.x documentation [here](https://docs.duendesoftware.com/identityserver/v6).
-{{% /notice %}}

--- a/IdentityServer/v7/docs/themes/hugo-theme-learn/layouts/partials/header.html
+++ b/IdentityServer/v7/docs/themes/hugo-theme-learn/layouts/partials/header.html
@@ -117,6 +117,7 @@
         <div id="head-tags">
         {{ partial "tags.html" . }}
         </div>
+        {{ partial "newer-content-warning.html" . }}
         {{ if .Params.chapter }}
           <div id="chapter">
         {{ end }}

--- a/IdentityServer/v7/docs/themes/hugo-theme-learn/layouts/partials/newer-content-warning.html
+++ b/IdentityServer/v7/docs/themes/hugo-theme-learn/layouts/partials/newer-content-warning.html
@@ -1,0 +1,12 @@
+{{ if .Site.Params.NewContent.Enabled }}
+<div class="notices warning">
+  {{ $url := replace .Permalink .Site.Params.NewContent.Replace .Site.Params.NewContent.With }}
+  {{ if .Page.Params.NewContentUrl }}
+  {{ $url = .Page.Params.NewContentUrl }}
+  {{ end }}
+  <p><a class="highlight" href="https://duendesoftware.com/products/support">Version {{ .Site.Params.NewContent.CurrentVersion }} has been <span class="hljs-strong">out of support since {{ .Site.Params.NewContent.OutOfSupportSince }}</span></a>, and this
+    corresponding section of the documentation is no longer maintained. We strongly recommend you
+    <a class="highlight hljs-strong" href="{{ .Site.Params.NewContent.Url }}">upgrade to the latest supported version of {{ .Site.Params.NewContent.NewerVersion }}</a>
+    and <a class="highlight hljs-strong" href="{{ $url }}">read the latest version of this documentation.</a></p>
+</div>
+{{ end }}


### PR DESCRIPTION
Introduced a reusable `newer-content-warning.html` partial to display warnings for outdated documentation. Enabled and configured this warning for versions 5.x, 6.x, and 7.x with specific details about support timelines and recommended upgrades.

Note: The link attempts to replace the current version `/v5` with `/v7/`. There is also an override on specific pages with `newContentUrl` that allows us to change the URL if there isn't a matching page on the newer docs site. This will improve SEO traffic to newer documentation over time.

Before anyone asks, Hugo has a `{{ .RelPermalink }}` which is a relative permalink instead of an absolute permalink. I started with that approach but realized it was computational overkill to replace the baseurl, and the prefix of the current site to create a new destination URL. This approach works when in production, but the URL generated will likely have the wrong port locally.

![CleanShot 2025-02-03 at 15 16 01@2x](https://github.com/user-attachments/assets/7f10bded-d82a-4cc0-9307-2ecd21e93c26)
