### PR TITLE
Replace support repository link with community

### DIFF
--- a/IdentityServer/v5/docs/content/overview/support.md
+++ b/IdentityServer/v5/docs/content/overview/support.md
@@ -13,7 +13,7 @@ The IdentityServer [issue tracker](https://github.com/DuendeSoftware/IdentitySer
 Planned features and their [milestones](https://github.com/DuendeSoftware/IdentityServer/milestones) can be tracked using this [label](https://github.com/DuendeSoftware/IdentityServer/issues/new/choose).
 
 ### Developer Support
-Standard developer support and feature requests are handled via our public [developer support forum](https://github.com/DuendeSoftware/Support/issues).
+Standard developer support and feature requests are handled via our public [developer community](https://github.com/DuendeSoftware/community/discussions).
 
 Priority developer support is part of our Enterprise Edition. It provides access to a helpdesk system with a response time guarantee.
 Please [contact](https://duendesoftware.com/contact) us for more information.

--- a/IdentityServer/v6/docs/content/overview/glossary.md
+++ b/IdentityServer/v6/docs/content/overview/glossary.md
@@ -103,7 +103,7 @@ Can be either completely independent single deployments, or a single deployment 
 A single logical deployment that acts as multiple logical token services on multiple URLs or host names (e.g. for branding, isolation or multi-tenancy reasons).
 
 ## Standard Developer Support
-Online [forum](https://github.com/DuendeSoftware/Support/issues/) for Duende Software product issues and bugs.
+Online [developer community forum](https://github.com/DuendeSoftware/community/discussions) for Duende Software product issues and bugs.
 
 
 ## Priority Developer Support

--- a/IdentityServer/v6/docs/content/overview/support.md
+++ b/IdentityServer/v6/docs/content/overview/support.md
@@ -8,7 +8,7 @@ weight: 50
 You can find all source code for IdentityServer and its supporting repos in our [organization](https://github.com/duendesoftware).
 
 ### Issue Tracker
-The IdentityServer [issue tracker](https://github.com/DuendeSoftware/product/issues) and [pull requests](https://github.com/DuendeSoftware/product/pulls) allow you to follow the current work and [submit questions or bug reports](https://github.com/DuendeSoftware/community/discussions).
+The IdentityServer [issue tracker](https://github.com/DuendeSoftware/products/issues) and [pull requests](https://github.com/DuendeSoftware/products/pulls) allow you to follow the current work and [submit questions or bug reports](https://github.com/DuendeSoftware/community/discussions).
 
 [Milestones](https://github.com/DuendeSoftware/IdentityServer/milestones) / [release notes](https://github.com/DuendeSoftware/IdentityServer/releases)
 

--- a/IdentityServer/v6/docs/content/overview/support.md
+++ b/IdentityServer/v6/docs/content/overview/support.md
@@ -8,14 +8,14 @@ weight: 50
 You can find all source code for IdentityServer and its supporting repos in our [organization](https://github.com/duendesoftware).
 
 ### Issue Tracker
-The IdentityServer [issue tracker](https://github.com/DuendeSoftware/IdentityServer/issues) and [pull requests](https://github.com/DuendeSoftware/IdentityServer/pulls) allow you to follow the current work and [submit questions or bug reports](https://github.com/DuendeSoftware/Support/issues).
+The IdentityServer [issue tracker](https://github.com/DuendeSoftware/product/issues) and [pull requests](https://github.com/DuendeSoftware/product/pulls) allow you to follow the current work and [submit questions or bug reports](https://github.com/DuendeSoftware/community/discussions).
 
 [Milestones](https://github.com/DuendeSoftware/IdentityServer/milestones) / [release notes](https://github.com/DuendeSoftware/IdentityServer/releases)
 
 ### Support
 See [here](https://duendesoftware.com/products/support) for our support policy.
 
-Standard support and feature requests are handled via our public [support forum](https://github.com/DuendeSoftware/Support/issues). Please start a discussion there if you need help.
+Standard support and feature requests are handled via our public [developer community forum](https://github.com/DuendeSoftware/community/discussions). Please start a discussion there if you need help.
 
 [Priority support](https://duendesoftware.com/license/PrioritySupportLicense.pdf) is part of our Enterprise Edition. It includes a private email alias, guaranteed two US business days response time.
 

--- a/IdentityServer/v6/docs/content/samples/_index.md
+++ b/IdentityServer/v6/docs/content/samples/_index.md
@@ -13,6 +13,4 @@ clients and APIs needed to demonstrate the illustrated functionality. The "Basic
 
 The source code for the samples is in our samples [repository]({{< param samples_base >}}).
 
-Feel free to open a new BFF or IdentityServer [issue ](https://github.com/DuendeSoftware/Support/issues/new/choose) if you are looking for a particular sample and can't find it here.
-
-
+Feel free to [ask the developer community](https://github.com/DuendeSoftware/community/discussions) if you are looking for a particular sample and can't find it here.

--- a/IdentityServer/v7/docs/content/overview/glossary.md
+++ b/IdentityServer/v7/docs/content/overview/glossary.md
@@ -111,7 +111,7 @@ Can be either completely independent single deployments, or a single deployment 
 A single logical deployment that acts as multiple logical token services on multiple URLs or host names (e.g. for branding, isolation or multi-tenancy reasons).
 
 ## Standard Developer Support
-Online [forum](https://github.com/DuendeSoftware/Support/issues/) for Duende Software product issues and bugs.
+Online [developer community forum](https://github.com/DuendeSoftware/community/discussions) for Duende Software product issues and bugs.
 
 
 ## Priority Developer Support

--- a/IdentityServer/v7/docs/content/overview/support.md
+++ b/IdentityServer/v7/docs/content/overview/support.md
@@ -8,14 +8,15 @@ weight: 50
 You can find all source code for IdentityServer and its supporting repos in our [organization](https://github.com/duendesoftware).
 
 ### Issue Tracker
-The IdentityServer [issue tracker](https://github.com/DuendeSoftware/IdentityServer/issues) and [pull requests](https://github.com/DuendeSoftware/IdentityServer/pulls) allow you to follow the current work and [submit questions or bug reports](https://github.com/DuendeSoftware/Support/issues).
+The IdentityServer [issue tracker](https://github.com/DuendeSoftware/product/issues) and [pull requests](https://github.com/DuendeSoftware/product/pulls) allow you to follow the current work.
+Join our [developer community forum](https://github.com/DuendeSoftware/community/discussions) to ask questions and discuss potential bugs.
 
 [Milestones](https://github.com/DuendeSoftware/IdentityServer/milestones) / [release notes](https://github.com/DuendeSoftware/IdentityServer/releases)
 
 ### Support
 See [here](https://duendesoftware.com/products/support) for our support policy.
 
-Standard support and feature requests are handled via our public [support forum](https://github.com/DuendeSoftware/Support/issues). Please start a discussion there if you need help.
+Standard support and feature requests are handled via our public [developer community forum](https://github.com/DuendeSoftware/community/discussions). Please start a discussion there if you need help.
 
 [Priority support](https://duendesoftware.com/license/PrioritySupportLicense.pdf) is part of our Enterprise Edition. It includes a private email alias, guaranteed two US business days response time.
 

--- a/IdentityServer/v7/docs/content/overview/support.md
+++ b/IdentityServer/v7/docs/content/overview/support.md
@@ -8,7 +8,7 @@ weight: 50
 You can find all source code for IdentityServer and its supporting repos in our [organization](https://github.com/duendesoftware).
 
 ### Issue Tracker
-The IdentityServer [issue tracker](https://github.com/DuendeSoftware/product/issues) and [pull requests](https://github.com/DuendeSoftware/product/pulls) allow you to follow the current work.
+The IdentityServer [issue tracker](https://github.com/DuendeSoftware/products/issues) and [pull requests](https://github.com/DuendeSoftware/products/pulls) allow you to follow the current work.
 Join our [developer community forum](https://github.com/DuendeSoftware/community/discussions) to ask questions and discuss potential bugs.
 
 [Milestones](https://github.com/DuendeSoftware/IdentityServer/milestones) / [release notes](https://github.com/DuendeSoftware/IdentityServer/releases)

--- a/IdentityServer/v7/docs/content/samples/_index.md
+++ b/IdentityServer/v7/docs/content/samples/_index.md
@@ -13,6 +13,4 @@ clients and APIs needed to demonstrate the illustrated functionality. The "Basic
 
 The source code for the samples is in our samples [repository]({{< param samples_base >}}).
 
-Feel free to open a new BFF or IdentityServer [issue ](https://github.com/DuendeSoftware/Support/issues/new/choose) if you are looking for a particular sample and can't find it here.
-
-
+Feel free to [ask the developer community](https://github.com/DuendeSoftware/community/discussions) if you are looking for a particular sample and can't find it here.


### PR DESCRIPTION
Ready to go once Community repo is public.