### PR TITLE
Update glossary link to use ref shortcode

### DIFF
--- a/IdentityServer/v6/docs/content/overview/glossary.md
+++ b/IdentityServer/v6/docs/content/overview/glossary.md
@@ -117,4 +117,4 @@ Helpdesk system with guaranteed response time for Duende Software product issues
 ## Security Notification System
 Notification system for security bugs and/or reported vulnerabilities.
 
-[More details](https://docs.duendesoftware.com/identityserver/v6/overview/security/#vulnerability-management-process)
+[More details]({{<ref "/overview/security" >}}#vulnerability-management-process)

--- a/IdentityServer/v7/docs/content/overview/glossary.md
+++ b/IdentityServer/v7/docs/content/overview/glossary.md
@@ -125,4 +125,4 @@ Helpdesk system with guaranteed response time for Duende Software product issues
 ## Security Notification System
 Notification system for security bugs and/or reported vulnerabilities.
 
-[More details](https://docs.duendesoftware.com/identityserver/v6/overview/security/#vulnerability-management-process)
+[More details]({{<ref "/overview/security" >}}#vulnerability-management-process)


### PR DESCRIPTION
Replaced the static hyperlink with the Hugo ref shortcode for consistency and maintainability. This ensures proper handling of internal links and alignment with the project's documentation standards.