### PR TITLE
Replace deprecated breadcrumb metadata with Schema.org

### DIFF
--- a/IdentityServer/v5/docs/themes/hugo-theme-learn/layouts/partials/header.html
+++ b/IdentityServer/v5/docs/themes/hugo-theme-learn/layouts/partials/header.html
@@ -89,7 +89,7 @@
                 {{ end }}
               {{ end }}
               {{$toc := (and (not .Params.disableToc) (not .Params.chapter))}}
-              <div id="breadcrumbs" itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb">
+              <div id="breadcrumbs" itemscope="" itemtype="https://schema.org/BreadcrumbList">
                   <span id="sidebar-toggle-span">
                       <a href="#" id="sidebar-toggle" data-sidebar-toggle="">
                         <i class="fas fa-bars"></i>
@@ -101,7 +101,8 @@
                 <span class="links">
                 {{$showBreadcrumb := (and (not .Params.disableBreadcrumb) (not .Site.Params.disableBreadcrumb))}}
                 {{if $showBreadcrumb}}
-                  {{ template "breadcrumb" dict "page" . "value" .Title }}
+                  {{ $element := (printf "<span itemprop='itemListElement' itemscope itemtype='https://schema.org/ListItem'>%s</span>" .Title) }}
+                  {{ template "breadcrumb" dict "page" . "value" $element }}
                 {{ else }}
                   {{ .Title }}
                 {{ end }}
@@ -133,7 +134,7 @@
         {{define "breadcrumb"}}
           {{$parent := .page.Parent }}
           {{ if $parent }}
-            {{ $value := (printf "<a href='%s'>%s</a> > %s" $parent.RelPermalink $parent.Title .value) }}
+            {{ $value := (printf "<a itemprop='itemListElement' itemscope itemtype='https://schema.org/ListItem' href='%s'><span itemprop='name'>%s</span></a> > %s" $parent.RelPermalink $parent.Title .value) }}
             {{ template "breadcrumb" dict "page" $parent "value" $value }}
           {{else}}
             {{.value|safeHTML}}

--- a/IdentityServer/v6/docs/themes/hugo-theme-learn/layouts/partials/header.html
+++ b/IdentityServer/v6/docs/themes/hugo-theme-learn/layouts/partials/header.html
@@ -90,7 +90,7 @@
                   {{ end }}
                 {{ end }}
                 {{$toc := (and (not .Params.disableToc) (not .Params.chapter))}}
-                <div id="breadcrumbs" itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb">
+                <div id="breadcrumbs" itemscope="" itemtype="https://schema.org/BreadcrumbList">
                     <span id="sidebar-toggle-span">
                         <a href="#" id="sidebar-toggle" data-sidebar-toggle="">
                           <i class="fas fa-bars"></i>
@@ -102,9 +102,10 @@
                   <span class="links">
                  {{$showBreadcrumb := (and (not .Params.disableBreadcrumb) (not .Site.Params.disableBreadcrumb))}}
                  {{if $showBreadcrumb}}
-                    {{ template "breadcrumb" dict "page" . "value" .Title }}
+                    {{ $element := (printf "<span itemprop='itemListElement' itemscope itemtype='https://schema.org/ListItem'>%s</span>" .Title) }}
+                    {{ template "breadcrumb" dict "page" . "value" $element }}
                  {{ else }}
-                   {{ .Title }}
+                    {{.Title}}
                  {{ end }}
                   </span>
                 </div>
@@ -134,7 +135,7 @@
         {{define "breadcrumb"}}
           {{$parent := .page.Parent }}
           {{ if $parent }}
-            {{ $value := (printf "<a href='%s'>%s</a> > %s" $parent.RelPermalink $parent.Title .value) }}
+            {{ $value := (printf "<a itemprop='itemListElement' itemscope itemtype='https://schema.org/ListItem' href='%s'><span itemprop='name'>%s</span></a> > %s" $parent.RelPermalink $parent.Title .value) }}
             {{ template "breadcrumb" dict "page" $parent "value" $value }}
           {{else}}
             {{.value|safeHTML}}

--- a/IdentityServer/v7/docs/themes/hugo-theme-learn/layouts/partials/header.html
+++ b/IdentityServer/v7/docs/themes/hugo-theme-learn/layouts/partials/header.html
@@ -90,7 +90,7 @@
                   {{ end }}
                 {{ end }}
                 {{$toc := (and (not .Params.disableToc) (not .Params.chapter))}}
-                <div id="breadcrumbs" itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb">
+                <div id="breadcrumbs" itemscope="" itemtype="https://schema.org/BreadcrumbList">
                     <span id="sidebar-toggle-span">
                         <a href="#" id="sidebar-toggle" data-sidebar-toggle="">
                           <i class="fas fa-bars"></i>
@@ -102,7 +102,8 @@
                   <span class="links">
                  {{$showBreadcrumb := (and (not .Params.disableBreadcrumb) (not .Site.Params.disableBreadcrumb))}}
                  {{if $showBreadcrumb}}
-                    {{ template "breadcrumb" dict "page" . "value" .Title }}
+                    {{ $element := (printf "<span itemprop='itemListElement' itemscope itemtype='https://schema.org/ListItem'>%s</span>" .Title) }}
+                    {{ template "breadcrumb" dict "page" . "value" $element }}
                  {{ else }}
                    {{ .Title }}
                  {{ end }}
@@ -134,7 +135,7 @@
         {{define "breadcrumb"}}
           {{$parent := .page.Parent }}
           {{ if $parent }}
-            {{ $value := (printf "<a href='%s'>%s</a> > %s" $parent.RelPermalink $parent.Title .value) }}
+            {{ $value := (printf "<a itemprop='itemListElement' itemscope itemtype='https://schema.org/ListItem' href='%s'><span itemprop='name'>%s</span></a> > %s" $parent.RelPermalink $parent.Title .value) }}
             {{ template "breadcrumb" dict "page" $parent "value" $value }}
           {{else}}
             {{.value|safeHTML}}


### PR DESCRIPTION
### Description

This pull request updates the breadcrumb metadata to comply with modern standards by replacing the deprecated `http://data-vocabulary.org/Breadcrumb` with `https://schema.org/BreadcrumbList` and `https://schema.org/ListItem`. These changes enhance SEO performance and structured data compatibility.

These were causing errors in our Google Search Console. _Error Bonanza 🤠 _

![CleanShot 2025-02-10 at 10 05 22@2x](https://github.com/user-attachments/assets/2eacac1c-84a4-458b-8a1c-611b6ba7ece2)

