### PR TITLE
Add canonical link handling to custom headers

### DIFF
--- a/IdentityServer/v5/docs/themes/hugo-theme-learn/layouts/partials/canonical.html
+++ b/IdentityServer/v5/docs/themes/hugo-theme-learn/layouts/partials/canonical.html
@@ -1,0 +1,7 @@
+{{ if .Site.Params.NewContent.Enabled }}
+{{ $url := replace .Permalink .Site.Params.NewContent.Replace .Site.Params.NewContent.With }}
+{{ if .Page.Params.NewContentUrl }}
+{{ $url = .Page.Params.NewContentUrl }}
+{{ end }}
+<link rel="canonical" href="{{ $url }}" />
+{{ end}}

--- a/IdentityServer/v5/docs/themes/hugo-theme-learn/layouts/partials/custom-header.html
+++ b/IdentityServer/v5/docs/themes/hugo-theme-learn/layouts/partials/custom-header.html
@@ -1,5 +1,1 @@
-<!-- Partial intended to be overwritten to add custom headers, like CSS or any other info
-<style type="text/css">
-    /* Custom css */
-</style>
--->
+{{ partial "canonical.html" . }}

--- a/IdentityServer/v6/docs/themes/hugo-theme-learn/layouts/partials/canonical.html
+++ b/IdentityServer/v6/docs/themes/hugo-theme-learn/layouts/partials/canonical.html
@@ -1,0 +1,7 @@
+{{ if .Site.Params.NewContent.Enabled }}
+{{ $url := replace .Permalink .Site.Params.NewContent.Replace .Site.Params.NewContent.With }}
+{{ if .Page.Params.NewContentUrl }}
+{{ $url = .Page.Params.NewContentUrl }}
+{{ end }}
+<link rel="canonical" href="{{ $url }}" />
+{{ end}}

--- a/IdentityServer/v6/docs/themes/hugo-theme-learn/layouts/partials/custom-header.html
+++ b/IdentityServer/v6/docs/themes/hugo-theme-learn/layouts/partials/custom-header.html
@@ -1,5 +1,1 @@
-<!-- Partial intended to be overwritten to add custom headers, like CSS or any other info
-<style type="text/css">
-    /* Custom css */
-</style>
--->
+{{ partial "canonical.html" . }}

--- a/IdentityServer/v7/docs/themes/hugo-theme-learn/layouts/partials/canonical.html
+++ b/IdentityServer/v7/docs/themes/hugo-theme-learn/layouts/partials/canonical.html
@@ -1,0 +1,7 @@
+{{ if .Site.Params.NewContent.Enabled }}
+{{ $url := replace .Permalink .Site.Params.NewContent.Replace .Site.Params.NewContent.With }}
+{{ if .Page.Params.NewContentUrl }}
+{{ $url = .Page.Params.NewContentUrl }}
+{{ end }}
+<link rel="canonical" href="{{ $url }}" />
+{{ end}}

--- a/IdentityServer/v7/docs/themes/hugo-theme-learn/layouts/partials/custom-header.html
+++ b/IdentityServer/v7/docs/themes/hugo-theme-learn/layouts/partials/custom-header.html
@@ -1,5 +1,1 @@
-<!-- Partial intended to be overwritten to add custom headers, like CSS or any other info
-<style type="text/css">
-    /* Custom css */
-</style>
--->
+{{ partial "canonical.html" . }}


### PR DESCRIPTION
### Description of Changes

This pull request introduces a `canonical.html` partial for managing canonical URLs, ensuring uniformity and simplicity across versions. Updates include:

- Integration of the `canonical.html` partial into `custom-header.html` for versions v5, v6, and v7.
- Canonical links now consistently point to the latest version, aiding SEO by reducing duplicate content issues for similar pages.

These adjustments enhance SEO practices by improving canonical link handling across all versions.