### PR TITLE
Refactor breadcrumb markup for schema.org compliance

### DIFF
--- a/FOSS/themes/hugo-theme-learn/layouts/partials/header.html
+++ b/FOSS/themes/hugo-theme-learn/layouts/partials/header.html
@@ -135,7 +135,7 @@
           {{ if $parent }}
           {{ template "breadcrumb" (dict "page" $parent "value" "" "count" (add .count 1)) }}
           {{ end }}
-          {{ $value := (printf "%s<a itemprop='itemListElement' itemscope itemtype='https://schema.org/ListItem' href='%s'><span itemprop='name'>%s</span><meta itemprop='position' content='%d'></a>" .value .page.RelPermalink .page.Title .count) }}
+          {{ $value := (printf "%s<a itemprop='itemListElement' itemtype='https://schema.org/ListItem' href='%s'>%s<meta itemprop='name' content='%s'><meta itemprop='position' content='%d'></a>" .value .page.RelPermalink .page.Title .page.Title .count) }}
           {{ $value | safeHTML }}
           {{ if gt .count 1 }}
           <i class="fas fa-angle-right"></i>

--- a/IdentityServer/v5/docs/themes/hugo-theme-learn/layouts/partials/header.html
+++ b/IdentityServer/v5/docs/themes/hugo-theme-learn/layouts/partials/header.html
@@ -135,7 +135,7 @@
           {{ if $parent }}
           {{ template "breadcrumb" (dict "page" $parent "value" "" "count" (add .count 1)) }}
           {{ end }}
-          {{ $value := (printf "%s<a itemprop='itemListElement' itemscope itemtype='https://schema.org/ListItem' href='%s'><span itemprop='name'>%s</span><meta itemprop='position' content='%d'></a>" .value .page.RelPermalink .page.Title .count) }}
+          {{ $value := (printf "%s<a itemprop='itemListElement' itemtype='https://schema.org/ListItem' href='%s'>%s<meta itemprop='name' content='%s'><meta itemprop='position' content='%d'></a>" .value .page.RelPermalink .page.Title .page.Title .count) }}
           {{ $value | safeHTML }}
           {{ if gt .count 1 }}
           <i class="fas fa-angle-right"></i>

--- a/IdentityServer/v6/docs/themes/hugo-theme-learn/layouts/partials/header.html
+++ b/IdentityServer/v6/docs/themes/hugo-theme-learn/layouts/partials/header.html
@@ -136,7 +136,7 @@
           {{ if $parent }}
           {{ template "breadcrumb" (dict "page" $parent "value" "" "count" (add .count 1)) }}
           {{ end }}
-          {{ $value := (printf "%s<a itemprop='itemListElement' itemscope itemtype='https://schema.org/ListItem' href='%s'><span itemprop='name'>%s</span><meta itemprop='position' content='%d'></a>" .value .page.RelPermalink .page.Title .count) }}
+          {{ $value := (printf "%s<a itemprop='itemListElement' itemtype='https://schema.org/ListItem' href='%s'>%s<meta itemprop='name' content='%s'><meta itemprop='position' content='%d'></a>" .value .page.RelPermalink .page.Title .page.Title .count) }}
           {{ $value | safeHTML }}
           {{ if gt .count 1 }}
           <i class="fas fa-angle-right"></i>

--- a/IdentityServer/v7/docs/themes/hugo-theme-learn/layouts/partials/header.html
+++ b/IdentityServer/v7/docs/themes/hugo-theme-learn/layouts/partials/header.html
@@ -136,7 +136,7 @@
           {{ if $parent }}
           {{ template "breadcrumb" (dict "page" $parent "value" "" "count" (add .count 1)) }}
           {{ end }}
-          {{ $value := (printf "%s<a itemprop='itemListElement' itemscope itemtype='https://schema.org/ListItem' href='%s'><span itemprop='name'>%s</span><meta itemprop='position' content='%d'></a>" .value .page.RelPermalink .page.Title .count) }}
+          {{ $value := (printf "%s<a itemprop='itemListElement' itemtype='https://schema.org/ListItem' href='%s'>%s<meta itemprop='name' content='%s'><meta itemprop='position' content='%d'></a>" .value .page.RelPermalink .page.Title .page.Title .count) }}
           {{ $value | safeHTML }}
           {{ if gt .count 1 }}
           <i class="fas fa-angle-right"></i>


### PR DESCRIPTION
### Description
This pull request refactors breadcrumb markup to improve compliance with schema.org standards. Changes include:
- Removal of unnecessary `itemscope` attributes.
- Adjustment of element structures.
- Moving `itemprop="name"` to a `<meta>` tag.

These updates are applied consistently across multiple versions and themes to ensure alignment with schema.org standards.