### PR TITLE
Add note on X.509 certificate expiration in documentation

### DIFF
--- a/IdentityServer/v7/docs/content/fundamentals/keys/automatic_key_management.md
+++ b/IdentityServer/v7/docs/content/fundamentals/keys/automatic_key_management.md
@@ -103,7 +103,7 @@ each signing algorithm you specify.
 
 {{% notice info %}}
 
-When using a *X.509 certificates*, the certificate may have an expiration date, but IdentityServer does
+*X.509 certificates* have an expiration date, but IdentityServer does
 not use this data to validate the certificate and throw an exception. If a certificate has expired then you
 must decide whether to continue using it or replace it with a new certificate.
 

--- a/IdentityServer/v7/docs/content/fundamentals/keys/automatic_key_management.md
+++ b/IdentityServer/v7/docs/content/fundamentals/keys/automatic_key_management.md
@@ -101,6 +101,14 @@ multiple keys, algorithms, and if those keys should additionally get wrapped in
 an X.509 certificate. Automatic key management will create and rotate keys for
 each signing algorithm you specify.
 
+{{% notice info %}}
+
+When using a *X.509 certificates*, the certificate may have an expiration date, but IdentityServer does
+not use this data to validate the certificate and throw an exception. If a certificate has expired then you
+must decide whether to continue using it or replace it with a new certificate.
+
+{{% /notice %}}
+
 ```cs
 options.KeyManagement.SigningAlgorithms = new[]
 {

--- a/IdentityServer/v7/docs/content/reference/options.md
+++ b/IdentityServer/v7/docs/content/reference/options.md
@@ -85,6 +85,14 @@ Automatic key management settings. Available on the *KeyManagement* property of 
 
     Defaults to *RS256* without an X.509 certificate.
 
+  {{% notice info %}}
+  
+  When using a *X.509 certificates*, the certificate may have an expiration date, but IdentityServer does
+  not use this data to validate the certificate and throw an exception. If a certificate has expired then you
+  must decide whether to continue using it or replace it with a new certificate.
+  
+  {{% /notice %}}
+
 * ***RsaKeySize***
     
     Key size (in bits) of RSA keys. The signing algorithms that use RSA keys (*RS256*, *RS384*, *RS512*, *PS256*, *PS384*, and *PS512*) will generate an RSA key of this length. Defaults to 2048.

--- a/IdentityServer/v7/docs/content/reference/options.md
+++ b/IdentityServer/v7/docs/content/reference/options.md
@@ -87,7 +87,7 @@ Automatic key management settings. Available on the *KeyManagement* property of 
 
   {{% notice info %}}
   
-  When using a *X.509 certificates*, the certificate may have an expiration date, but IdentityServer does
+*X.509 certificates* have an expiration date, but IdentityServer does
   not use this data to validate the certificate and throw an exception. If a certificate has expired then you
   must decide whether to continue using it or replace it with a new certificate.
   


### PR DESCRIPTION
### Description

This pull request adds a note to the documentation clarifying that IdentityServer does not validate X.509 certificate expiration automatically. It emphasizes that users are responsible for determining when to replace certificates, enhancing understanding of key management practices and options. 

### Related Issues

- #466
