### PR TITLE
Use `protected override` instead of `protected internal override` (get rid of CS0507 error when overriding the method)

### DIFF
--- a/IdentityServer/v5/docs/content/ui/custom.md
+++ b/IdentityServer/v5/docs/content/ui/custom.md
@@ -29,7 +29,7 @@ public class CustomAuthorizeInteractionResponseGenerator : AuthorizeInteractionR
     {
     }
 
-    protected internal override async Task<InteractionResponse> ProcessLoginAsync(ValidatedAuthorizeRequest request)
+    protected override async Task<InteractionResponse> ProcessLoginAsync(ValidatedAuthorizeRequest request)
     {
         var result = await base.ProcessLoginAsync(request);
 

--- a/IdentityServer/v6/docs/content/ui/custom.md
+++ b/IdentityServer/v6/docs/content/ui/custom.md
@@ -29,7 +29,7 @@ public class CustomAuthorizeInteractionResponseGenerator : AuthorizeInteractionR
     {
     }
 
-    protected internal override async Task<InteractionResponse> ProcessLoginAsync(ValidatedAuthorizeRequest request)
+    protected override async Task<InteractionResponse> ProcessLoginAsync(ValidatedAuthorizeRequest request)
     {
         var result = await base.ProcessLoginAsync(request);
 

--- a/IdentityServer/v7/docs/content/ui/custom.md
+++ b/IdentityServer/v7/docs/content/ui/custom.md
@@ -29,7 +29,7 @@ public class CustomAuthorizeInteractionResponseGenerator : AuthorizeInteractionR
     {
     }
 
-    protected internal override async Task<InteractionResponse> ProcessLoginAsync(ValidatedAuthorizeRequest request)
+    protected override async Task<InteractionResponse> ProcessLoginAsync(ValidatedAuthorizeRequest request)
     {
         var result = await base.ProcessLoginAsync(request);
 


### PR DESCRIPTION
Use `protected override` instead of `protected internal override` (get rid of CS0507 error when overriding the method)


https://github.com/orgs/DuendeSoftware/discussions/111