### PR TITLE
Add upgrade guide for Duende IdentityServer v7.1 to v7.2

### DIFF
--- a/IdentityServer/v7/docs/content/upgrades/v7.1_to_v7.2.md
+++ b/IdentityServer/v7/docs/content/upgrades/v7.1_to_v7.2.md
@@ -1,0 +1,40 @@
+---
+title: "Duende IdentityServer v7.1 to v7.2"
+weight: 28
+---
+
+This upgrade guide covers upgrading from Duende IdentityServer v7.1 to v7.2 ([release notes](https://github.com/DuendeSoftware/IdentityServer/releases/tag/7.2.0)).
+
+## What's New
+Duende IdentityServer 7.2 adds:
+- Do not issue *TokenIssuedFailureEvent* for *use_dpop_nonce* error
+- Use *AsyncServiceScope* in Background Services
+- Use query-safe URL fragment when returning an error
+- Add an option for strict validation of assertion audiences
+- General improvements to XML documentation and null reference exception handling
+- Preview Features: Strict Audience Validation and Discovery Document Caching
+- Bug fixes and ongoing maintenance
+
+There are no changes to the data stores in this release.
+
+## Step 1: Update NuGet package
+
+In your IdentityServer host project, update the version of the NuGet.
+For example in your project file:
+
+```
+<PackageReference Include="Duende.IdentityServer" Version="7.1.0" />
+```
+
+would change to:
+
+```
+<PackageReference Include="Duende.IdentityServer" Version="7.2.0" />
+```
+
+## Step 2: Verify Data Protection Configuration
+IdentityServer depends on ASP.NET Data Protection. Data Protection encrypts and signs data using keys managed by ASP.NET. Those keys are isolated by application name, which by default is set to the content root path of the host. This prevents multiple applications from sharing encryption keys, which is necessary to protect your encryption against certain forms of attack. However, this means that if your content root path changes, the default settings for data protection will prevent you from using your old keys. Beginning in .NET 6, the content root path was normalized so that it ends with a directory separator. In .NET 7 that change was reverted. This means that your content root path might change if you upgrade from .NET 6 to .NET 7. This can be mitigated by explicitly setting the application name and removing the separator character. See [Microsoft's documentation for more information](https://learn.microsoft.com/en-us/aspnet/core/security/data-protection/configuration/overview?view=aspnetcore-7.0#setapplicationname).
+
+## Step 3: Done!
+
+That's it. Of course, at this point you can and should test that your IdentityServer is updated and working properly.

--- a/IdentityServer/v7/docs/content/upgrades/v7.1_to_v7.2.md
+++ b/IdentityServer/v7/docs/content/upgrades/v7.1_to_v7.2.md
@@ -32,9 +32,7 @@ would change to:
 <PackageReference Include="Duende.IdentityServer" Version="7.2.0" />
 ```
 
-## Step 2: Verify Data Protection Configuration
-IdentityServer depends on ASP.NET Data Protection. Data Protection encrypts and signs data using keys managed by ASP.NET. Those keys are isolated by application name, which by default is set to the content root path of the host. This prevents multiple applications from sharing encryption keys, which is necessary to protect your encryption against certain forms of attack. However, this means that if your content root path changes, the default settings for data protection will prevent you from using your old keys. Beginning in .NET 6, the content root path was normalized so that it ends with a directory separator. In .NET 7 that change was reverted. This means that your content root path might change if you upgrade from .NET 6 to .NET 7. This can be mitigated by explicitly setting the application name and removing the separator character. See [Microsoft's documentation for more information](https://learn.microsoft.com/en-us/aspnet/core/security/data-protection/configuration/overview?view=aspnetcore-7.0#setapplicationname).
 
-## Step 3: Done!
+## Step 2: Done!
 
 That's it. Of course, at this point you can and should test that your IdentityServer is updated and working properly.


### PR DESCRIPTION
### Description

This pull request adds an upgrade guide for transitioning from Duende IdentityServer v7.1 to v7.2. The guide includes:
- Clear steps for NuGet package updates.
- Information on handling data protection configuration.
- A summary of new features, bug fixes, and improvements in v7.2.

This documentation aims to assist developers in smoothly upgrading their implementation to the latest version.