### PR TITLE
Add `newContentUrl` links for updated BFF documentation

### DIFF
--- a/BFF/v2/docs/content/apis/_index.md
+++ b/BFF/v2/docs/content/apis/_index.md
@@ -2,6 +2,7 @@
 title = "API Endpoints"
 weight = 40
 chapter = true
+newContentUrl: "https://docs.duendesoftware.com/bff/v3/fundamentals/apis/"
 +++
 
 # Securing and Accessing API Endpoints

--- a/BFF/v2/docs/content/apis/local.md
+++ b/BFF/v2/docs/content/apis/local.md
@@ -1,6 +1,7 @@
 ---
 title: "Local APIs"
 weight: 10
+newContentUrl: "https://docs.duendesoftware.com/bff/v3/fundamentals/apis/local/"
 ---
 
 A _Local API_ is an API that is located within the BFF host. Local APIs are implemented with the familiar ASP.NET abstractions of API controllers or minimal API endpoints. 

--- a/BFF/v2/docs/content/apis/remote.md
+++ b/BFF/v2/docs/content/apis/remote.md
@@ -1,6 +1,7 @@
 ---
 title: "Remote APIs"
 weight: 20
+newContentUrl: "https://docs.duendesoftware.com/bff/v3/fundamentals/apis/remote/"
 ---
 
 A _Remote API_ is an API that is deployed separately from the BFF host. Remote APIs use access tokens to authenticate and authorize requests, but the frontend does not possess an access token to make requests to remote APIs directly. Instead, all access to remote APIs is proxied through the BFF, which authenticates the frontend using its authentication cookie, obtains the appropriate access token, and forwards the request to the Remote API with the token attached.

--- a/BFF/v2/docs/content/apis/yarp.md
+++ b/BFF/v2/docs/content/apis/yarp.md
@@ -1,6 +1,7 @@
 ---
 title: "YARP extensions"
 weight: 30
+newContentUrl: "https://docs.duendesoftware.com/bff/v3/fundamentals/yarp/"
 ---
 
 Duende.BFF integrates with Microsoft's full-featured reverse proxy [YARP](https://microsoft.github.io/reverse-proxy/).

--- a/BFF/v2/docs/content/session/_index.md
+++ b/BFF/v2/docs/content/session/_index.md
@@ -3,6 +3,7 @@ title = "Authentication & Session Management"
 date = 2020-09-10T08:20:20+02:00
 weight = 20
 chapter = true
+newContentUrl: "https://docs.duendesoftware.com/bff/v3/fundamentals/session/"
 +++
 
 # Authentication & Session Management

--- a/BFF/v2/docs/content/session/handlers.md
+++ b/BFF/v2/docs/content/session/handlers.md
@@ -2,6 +2,7 @@
 title: "ASP.NET Core Authentication System"
 date: 2020-09-10T08:22:12+02:00
 weight: 10
+newContentUrl: "https://docs.duendesoftware.com/bff/v3/fundamentals/session/handlers/"
 ---
 
 You typically use the following two ASP.NET Core authentication handlers to implement remote authentication:

--- a/BFF/v2/docs/content/session/management/_index.md
+++ b/BFF/v2/docs/content/session/management/_index.md
@@ -2,6 +2,7 @@
 title: "BFF Session Management Endpoints"
 menuTitle: "Session Management Endpoints"
 weight: 20
+newContentUrl: "https://docs.duendesoftware.com/bff/v3/fundamentals/session/management/"
 ---
 
 Duende.BFF adds endpoints for performing typical session-management operations such as triggering login and logout and getting information about the currently logged-on user. These endpoint are meant to be called by the frontend.

--- a/BFF/v2/docs/content/session/management/back-channel-logout.md
+++ b/BFF/v2/docs/content/session/management/back-channel-logout.md
@@ -3,6 +3,7 @@ title: "BFF Back-Channel Logout Endpoint"
 menuTitle: "Back-Channel Logout"
 date: 2022-12-29T10:22:12+02:00
 weight: 50
+newContentUrl: "https://docs.duendesoftware.com/bff/v3/fundamentals/session/management/back-channel-logout/"
 ---
 
 The */bff/backchannel* endpoint is an implementation of the [OpenID Connect Back-Channel Logout](https://openid.net/specs/openid-connect-backchannel-1_0.html) specification. The remote identity provider can use this endpoint to end the BFF's session via a server to server call, without involving the user's browser. This design avoids problems with 3rd party cookies associated with front-channel logout.

--- a/BFF/v2/docs/content/session/management/diagnostics.md
+++ b/BFF/v2/docs/content/session/management/diagnostics.md
@@ -3,6 +3,7 @@ title: "BFF Diagnostics Endpoint"
 menuTitle: "Diagnostics"
 date: 2022-12-29T10:22:12+02:00
 weight: 40
+newContentUrl: "https://docs.duendesoftware.com/bff/v3/fundamentals/session/management/diagnostics/"
 ---
 
 The */bff/diagnostics* endpoint returns the current user and client access token for testing purposes. The endpoint tries to retrieve and show current tokens. It may invoke both a refresh token flow for the user access token and a client credential flow for the client access token.

--- a/BFF/v2/docs/content/session/management/login.md
+++ b/BFF/v2/docs/content/session/management/login.md
@@ -3,6 +3,7 @@ title: "BFF Login Endpoint"
 menuTitle: "Login"
 date: 2020-09-10T08:22:12+02:00
 weight: 20
+newContentUrl: "https://docs.duendesoftware.com/bff/v3/fundamentals/session/management/login/"
 ---
 
 The */bff/login* endpoint begins the authentication process. To use it, typically javascript code will navigate away from the frontend application to the login endpoint:

--- a/BFF/v2/docs/content/session/management/logout.md
+++ b/BFF/v2/docs/content/session/management/logout.md
@@ -3,6 +3,7 @@ title: "BFF Logout Endpoint"
 menuTitle: "Logout"
 date: 2022-12-29T10:22:12+02:00
 weight: 30
+newContentUrl: "https://docs.duendesoftware.com/bff/v3/fundamentals/session/management/logout/"
 ---
 
 The */bff/logout* endpoint signs out of the appropriate ASP.NET Core [authentication schemes]({{< ref "handlers" >}}) to both delete the BFF's session cookie and to sign out from the remote identity provider. To use the logout endpoint, typically your javascript code will navigate away from your front end to the logout endpoint, similar to the login endpoint. However, unlike the login endpoint, the logout endpoint requires CSRF protection, otherwise an attacker could destroy sessions by making cross-site GET requests. The session id is used to provide this CSRF protection by requiring it as a query parameter to the logout endpoint (assuming that a session id was included during login). For convenience, the correct logout url is made available as a claim in the */bff/user* endpoint, making typical logout usage look like this:

--- a/BFF/v2/docs/content/session/management/silent-login.md
+++ b/BFF/v2/docs/content/session/management/silent-login.md
@@ -3,6 +3,7 @@ title: "BFF Silent Login Endpoint"
 menuTitle: "Silent Login"
 date: 2022-12-29T10:22:12+02:00
 weight: 35
+newContentUrl: "https://docs.duendesoftware.com/bff/v3/fundamentals/session/management/silent-login/"
 ---
 
 Added in v1.2.0.

--- a/BFF/v2/docs/content/session/management/user.md
+++ b/BFF/v2/docs/content/session/management/user.md
@@ -3,6 +3,7 @@ title: "BFF User Endpoint"
 menuTitle: "User"
 date: 2022-12-29T10:22:12+02:00
 weight: 25
+newContentUrl: "https://docs.duendesoftware.com/bff/v3/fundamentals/session/management/user/"
 ---
 
 The */bff/user* endpoint returns data about the currently logged-on user and the session. It is typically invoked at application startup to check if the user has authenticated, and if so, to get profile data about the user. It can also be used to periodically query if the session is still valid.

--- a/BFF/v2/docs/content/session/server_side_sessions.md
+++ b/BFF/v2/docs/content/session/server_side_sessions.md
@@ -2,6 +2,7 @@
 title: "Server-side Sessions"
 description: "BFF"
 weight: 40
+newContentUrl: "https://docs.duendesoftware.com/bff/v3/fundamentals/session/server_side_sessions/"
 ---
 
 By default, ASP.NET Core's cookie handler will store all user session data in a protected cookie. This works very well unless cookie size or revocation becomes an issue.


### PR DESCRIPTION
Added `newContentUrl` metadata to multiple documentation files, linking to the updated v3 Duende BFF documentation. This ensures clear redirection to the latest resources for session management, APIs, and related topics.