### PR TITLE
Fix syntax issues in markdown and update URL formatting

### DIFF
--- a/BFF/v2/docs/content/apis/_index.md
+++ b/BFF/v2/docs/content/apis/_index.md
@@ -2,7 +2,7 @@
 title = "API Endpoints"
 weight = 40
 chapter = true
-newContentUrl: "https://docs.duendesoftware.com/bff/v3/fundamentals/apis/"
+newContentUrl = "https://docs.duendesoftware.com/bff/v3/fundamentals/apis/"
 +++
 
 # Securing and Accessing API Endpoints

--- a/BFF/v2/docs/content/session/_index.md
+++ b/BFF/v2/docs/content/session/_index.md
@@ -3,7 +3,7 @@ title = "Authentication & Session Management"
 date = 2020-09-10T08:20:20+02:00
 weight = 20
 chapter = true
-newContentUrl: "https://docs.duendesoftware.com/bff/v3/fundamentals/session/"
+newContentUrl = "https://docs.duendesoftware.com/bff/v3/fundamentals/session/"
 +++
 
 # Authentication & Session Management

--- a/BFF/v3/docs/content/fundamentals/session/handlers.md
+++ b/BFF/v3/docs/content/fundamentals/session/handlers.md
@@ -106,5 +106,5 @@ This also happens when you have an identity provider that's hosted on a differen
 So, if you have an Identity Provider that's hosted under a different site than your BFF, you may want to configure your cookie policy to be `SameSiteMode.Lax`.
 
 {{% notice note %}}
-Chrome will make an exception for cookies set without a `SameSite` attribute less than 2 minutes ago. Such cookies will also be sent with non-idempotent (e.g. POST) top-level cross-site requests despite normal `SameSite=Lax` cookies requiring top-level cross-site requests to have a safe (e.g. GET) HTTP method. Support for this intervention ("Lax + POST") will be removed in the future. (source: chromestatus)[https://chromestatus.com/feature/5088147346030592]
+Chrome will make an exception for cookies set without a `SameSite` attribute less than 2 minutes ago. Such cookies will also be sent with non-idempotent (e.g. POST) top-level cross-site requests despite normal `SameSite=Lax` cookies requiring top-level cross-site requests to have a safe (e.g. GET) HTTP method. Support for this intervention ("Lax + POST") will be removed in the future. (source: [chromestatus](https://chromestatus.com/feature/5088147346030592))
 {{% /notice %}}


### PR DESCRIPTION
Corrected the syntax for `newContentUrl` entries by replacing `:` with `=` for consistency. Adjusted markdown link formatting in the session handlers documentation for clarity and adherence to proper syntax.