### PR TITLE
Update workflow permissions for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
     env: 
       AZURE_STATIC_WEB_APPS_API_TOKEN_HAPPY_OCEAN_048B8E60F: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_HAPPY_OCEAN_048B8E60F }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     name: Build and Deploy Job
     steps:
       - uses: actions/checkout@v2
@@ -46,6 +49,10 @@ jobs:
     env: 
       AZURE_STATIC_WEB_APPS_API_TOKEN_HAPPY_OCEAN_048B8E60F: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_HAPPY_OCEAN_048B8E60F }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     name: Close Pull Request Job
     steps:
       - name: Close Pull Request

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -15,6 +15,10 @@ on:
 jobs:
   link_checker_job:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     name: Link Checker Job
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This pull request updates the permissions for CI and link checker workflows in GitHub Actions. Explicit permissions for contents, pull-requests, and issues have been added to improve security and adhere to the principle of least privilege. These changes ensure the workflows have scoped access only to the resources required for functionality.