### PR TITLE
Add rehype-external-links for external link handling

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,6 +11,7 @@ import starlightLlmsTxt from "starlight-llms-txt";
 import rehypeAstroRelativeMarkdownLinks from "astro-rehype-relative-markdown-links";
 import opengraphImages from "astro-opengraph-images";
 import { duendeOpenGraphImage } from "./src/components/duende-og-image.js";
+import rehypeExternalLinks from "rehype-external-links";
 import * as fs from "node:fs";
 
 // https://astro.build/config
@@ -75,7 +76,7 @@ export default defineConfig({
             defer: true,
             async: true,
           },
-        }
+        },
       ],
       logo: {
         light: "./src/assets/duende-logo.svg",
@@ -189,6 +190,13 @@ export default defineConfig({
               base: false,
             },
           },
+        },
+      ],
+      [
+        rehypeExternalLinks,
+        {
+          target: "_blank",
+          rel: ["noopener", "noreferrer"],
         },
       ],
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "jsdom": "^26.0.0",
         "patch-package": "^8.0.0",
         "react": "^19.0.0",
-        "rehype-autolink-headings": "^7.1.0",
+        "rehype-external-links": "^3.0.0",
         "satori": "^0.12.1",
         "sharp": "^0.34.1",
         "starlight-auto-sidebar": "^0.1.1",
@@ -5623,19 +5623,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-heading-rank": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
-      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-is-body-ok-link": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
@@ -8903,24 +8890,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/rehype-autolink-headings": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-7.1.0.tgz",
-      "integrity": "sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "hast-util-heading-rank": "^3.0.0",
-        "hast-util-is-element": "^3.0.0",
-        "unified": "^11.0.0",
-        "unist-util-visit": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/rehype-expressive-code": {
       "version": "0.41.1",
       "resolved": "https://registry.npmjs.org/rehype-expressive-code/-/rehype-expressive-code-0.41.1.tgz",
@@ -8928,6 +8897,24 @@
       "license": "MIT",
       "dependencies": {
         "expressive-code": "^0.41.1"
+      }
+    },
+    "node_modules/rehype-external-links": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+      "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "is-absolute-url": "^4.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rehype-format": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jsdom": "^26.0.0",
     "patch-package": "^8.0.0",
     "react": "^19.0.0",
+    "rehype-external-links": "^3.0.0",
     "satori": "^0.12.1",
     "sharp": "^0.34.1",
     "starlight-auto-sidebar": "^0.1.1",


### PR DESCRIPTION
### Description

This pull request integrates the `rehype-external-links` package into the project. It configures the Astro framework to open external links in a new tab and adds the `noopener` and `noreferrer` attributes for enhanced security and usability.

### Changes

- Included the `rehype-external-links` package in the project.
- Updated Astro configuration to manage external links with the specified settings.

