### PR TITLE
Add documentation for IdentityModel's Base64Url utility

### DIFF
--- a/.idea/docs.duendesoftware.com.iml
+++ b/.idea/docs.duendesoftware.com.iml
@@ -6,6 +6,8 @@
       <excludeFolder url="file://$MODULE_DIR$/temp" />
       <excludeFolder url="file://$MODULE_DIR$/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/root" />
+      <excludeFolder url="file://$MODULE_DIR$/.astro" />
+      <excludeFolder url="file://$MODULE_DIR$/.fleet" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/src/content/docs/identitymodel/utils/base64.md
+++ b/src/content/docs/identitymodel/utils/base64.md
@@ -37,6 +37,9 @@ bytes = WebEncoders.Base64UrlDecode(b64url);
 
 var text = Encoding.UTF8.GetString(bytes); 
 Console.WriteLine(text);
+```
+
+## IdentityModel's Base64Url
 
 IdentityModel includes the *Base64Url* class to help with
 encoding/decoding:


### PR DESCRIPTION

The formatting of this page was broken in a commit suggestion that was merged. Fixed now.