### PR TITLE
Update OAuth terminology to "OAuth 2.0" for consistency

### DIFF
--- a/src/content/docs/bff/index.mdx
+++ b/src/content/docs/bff/index.mdx
@@ -75,7 +75,7 @@ It offers the following functionality:
 
 - Protection from Token Extraction attacks
 - Built-in CSRF Attack protection
-- Server Side OAuth2 Authentication
+- Server Side OAuth 2.0 Support
 - User Management APIs
 - Back-channel logout
 - Securing access to both local and external APIs by serving as a reverse proxy.

--- a/src/content/docs/identitymodel/utils/request-url.md
+++ b/src/content/docs/identitymodel/utils/request-url.md
@@ -1,6 +1,6 @@
 ---
 title: Creating Authorize and EndSession URLs
-description: Helper utilities for creating OAuth2/OpenID Connect authorization and end session URLs with query parameters
+description: Helper utilities for creating OAuth 2.0/OpenID Connect authorization and end session URLs with query parameters
 sidebar:
   order: 4
   label: Authorize & EndSession URLs


### PR DESCRIPTION
Updated all references to use "OAuth 2.0" consistently across the documentation and codebase. This aligns terminology with industry standards and improves clarity.