### PR TITLE
Correct CLI command for empty IdentityServer template

### DIFF
--- a/src/content/docs/identityserver/quickstarts/1-client-credentials.md
+++ b/src/content/docs/identityserver/quickstarts/1-client-credentials.md
@@ -81,7 +81,7 @@ configuration added for it.
 
 ```console
 cd src
-dotnet new isempty -n IdentityServer
+dotnet new duende-is-empty -n IdentityServer
 ```
 
 This will create the following files within a new `src/IdentityServer` directory:


### PR DESCRIPTION
Fixes incorrect `dotnet new` template name to ensure the CLI example works as intended when creating a new IdentityServer project.