### PR TITLE
Updated the upgrade to 7.3 docs with a breaking change concerning client_secret_jwt

### DIFF
--- a/src/content/docs/identityserver/tokens/client-authentication.md
+++ b/src/content/docs/identityserver/tokens/client-authentication.md
@@ -118,9 +118,9 @@ The following secret validators are part of Duende IdentityServer:
 
 ## Shared Secrets
 
-Shared secrets is by far the most common technique for authenticating clients.
+Using shared secrets is by far the most common technique for authenticating clients.
 
-From a security point of view they have some shortcomings
+From a security point of view, they have some shortcomings:
 
 * the shared secrets must be transmitted over the network during authentication
 * they should not be persisted in clear text to reduce the risk of leaking them
@@ -152,7 +152,7 @@ var compromisedSecret = new Secret("just for demos, not prod!".Sha256());
 
 ### Authentication Using A Shared Secret
 
-You can either send the client id/secret combination as part of the POST body::
+You can either send the client id/secret combination as part of the POST body:
 
 ```http request
 POST /connect/token
@@ -167,7 +167,7 @@ Content-type: application/x-www-form-urlencoded
     redirect_uri=https://myapp.com/callback
 ```
 
-...or as a basic authentication header::
+...or as a basic authentication header:
 
 ```http request
 POST /connect/token
@@ -209,7 +209,7 @@ The OpenID Connect specification recommends a client authentication method based
 instead of transmitting the shared secret over the network, the client creates a JWT and signs it with its private key.
 Your IdentityServer only needs to store the corresponding key to be able to validate the signature.
 
-The technique is described [here](https://openid.net/specs/openid-connect-core-1_0.html#clientauthentication) and is
+The technique is described [here](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication) and is
 based on the OAuth JWT assertion specification [(RFC 7523)](https://tools.ietf.org/html/rfc7523).
 
 ### Setting Up A Private Key JWT Secret
@@ -230,7 +230,7 @@ var client = new Client
             Type = IdentityServerConstants.SecretTypes.X509CertificateBase64,
 
             Value = "MIID...xBXQ="
-        }
+        },
         new Secret
         {
             // JWK formatted RSA key
@@ -327,15 +327,14 @@ static async Task<TokenResponse> RequestTokenAsync(SigningCredentials credential
 }
 ```
 
-See [here](/identityserver/samples/basics#jwt-based-client-authentication) for a sample for using JWT-based
-authentication.
+See [here](/identityserver/samples/basics#jwt-based-client-authentication) for a sample for using JWT-based authentication.
 
 ### Using ASP.NET Core
 
 The OpenID Connect authentication handler in ASP.NET Core allows for replacing a static client secret with a dynamically
 created client assertion.
 
-This is accomplished by handling the various events on the handler. We recommend to encapsulate the event handler in a
+You can achieve this by handling the various events on the handler. We recommend encapsulating the event handler in a
 separate type. This makes it easier to consume services from DI:
 
 ```csharp
@@ -384,7 +383,7 @@ JWT-based authentication (and signed authorize requests) in ASP.NET Core.
 
 ## Strict Audience Validation
 
-Private key JWT have a theoretical vulnerability where a Relying Party trusting multiple
+Private key JWTs have a theoretical vulnerability where a Relying Party trusting multiple
 OpenID Providers could be attacked if one of the OpenID Providers is malicious or compromised.
 
 The attack relies on the OpenID Provider setting the audience value of the authentication JWT

--- a/src/content/docs/identityserver/upgrades/v7_2-to-v7_3.md
+++ b/src/content/docs/identityserver/upgrades/v7_2-to-v7_3.md
@@ -9,7 +9,7 @@ This upgrade guide covers upgrading from Duende IdentityServer v7.2 to v7.3 ([re
 
 IdentityServer 7.3.0 is a significant release that includes:
 
-- [FAPI 2.0 Security Profile](https://openid.net/specs/fapi-security-profile-2_0-final.html) certification
+- [FAPI 2.0 Security Profile][1] certification
 - JWT Response from the introspection endpoint ([RFC 9701](https://www.rfc-editor.org/rfc/rfc9701.html))
 - Diagnostic data
 - Removal of the experimental label from OpenTelemetry metrics
@@ -63,6 +63,64 @@ https://github.com/DuendeSoftware/products/pull/1796
 Several [OpenTelemetry metrics](/identityserver/diagnostics/otel.md#detailed-metrics) previously created by the meter named
 "Duende.IdentityServer.Experimental" have been moved to the "Duende.IdentityServer" meter.
 
+#### Default Supported Signing Algorithms Have Changed For Client Assertions And Request Objects
+
+To support the [FAPI 2.0 Security Profile][1], we've added new options to configure the supported signing algorithms for 
+client assertions and request objects, and only included asymmetric algorithms by default. Before this release, all 
+signing algorithms were supported, including the symmetric algorithms `HS256`, `HS384`, and `HS512`.
+ 
+If you're using symmetric keys to sign client assertions or request objects, you can restore the previous behavior by adding the 
+following code to your IdentityServer configuration:
+
+```csharp title="Program.cs" {4,18-20,24,38-40}
+builder.Services.AddIdentityServer(options =>
+{
+    // To re-enable symmetric algorithms for signing client assertions:
+    options.SupportedClientAssertionSigningAlgorithms = 
+    [
+        SecurityAlgorithms.RsaSha256,
+        SecurityAlgorithms.RsaSha384,
+        SecurityAlgorithms.RsaSha512,
+
+        SecurityAlgorithms.RsaSsaPssSha256,
+        SecurityAlgorithms.RsaSsaPssSha384,
+        SecurityAlgorithms.RsaSsaPssSha512,
+
+        SecurityAlgorithms.EcdsaSha256,
+        SecurityAlgorithms.EcdsaSha384,
+        SecurityAlgorithms.EcdsaSha512,
+
+        SecurityAlgorithms.HmacSha256,
+        SecurityAlgorithms.HmacSha384,
+        SecurityAlgorithms.HmacSha512
+    ];
+    
+    // To re-enable symmetric algorithms for signing request objects:
+    options.SupportedRequestObjectSigningAlgorithms = 
+    [
+        SecurityAlgorithms.RsaSha256,
+        SecurityAlgorithms.RsaSha384,
+        SecurityAlgorithms.RsaSha512,
+
+        SecurityAlgorithms.RsaSsaPssSha256,
+        SecurityAlgorithms.RsaSsaPssSha384,
+        SecurityAlgorithms.RsaSsaPssSha512,
+
+        SecurityAlgorithms.EcdsaSha256,
+        SecurityAlgorithms.EcdsaSha384,
+        SecurityAlgorithms.EcdsaSha512,
+
+        SecurityAlgorithms.HmacSha256,
+        SecurityAlgorithms.HmacSha384,
+        SecurityAlgorithms.HmacSha512
+    ];
+});
+```
+
+https://github.com/DuendeSoftware/products/pull/2077
+
 ## Step 3: Done!
 
 That's it. Of course, at this point you can and should test that your IdentityServer is updated and working properly.
+
+[1]: https://openid.net/specs/fapi-security-profile-2_0-final.html


### PR DESCRIPTION
Note that I didn't specifically mention `client_secret_jwt` because we also didn't have it in our discovery document in the past. We just "implicitly" supported it when someone used an HMAC SHA signing algorithm.

Fixes #779 