### PR TITLE
remove hello bar

### DIFF
--- a/src/data/banner.json
+++ b/src/data/banner.json
@@ -1,3 +1,3 @@
 {
-  "content" : "<strong>Livestream launch event:</strong> Duende IdentityServer v7.3 with FAPI 2.0 & new quickstart templates. <a href=\"https://duendesoftware.com/webinars/duende-identityserver-7-3-fapi-2-0\">Register now!</a>"
+  "content" : ""
 }


### PR DESCRIPTION
Don't merge before 8/21 at around 8 AM EST.

To coordinate with our Livestream on 8/21 @ 10 am, remove the Hello Bar banner from the website on Thursday at around 8 am EST.