### PR TITLE
Fix client assertion docs for V4

### DIFF
--- a/src/content/docs/accesstokenmanagement/advanced/client-assertions.mdx
+++ b/src/content/docs/accesstokenmanagement/advanced/client-assertions.mdx
@@ -43,16 +43,16 @@ public class ClientAssertionService(IOptionsSnapshot<ClientCredentialsClient> op
 
             var descriptor = new SecurityTokenDescriptor
             {
-                Issuer = options1.ClientId,
-                Audience = options1.TokenEndpoint,
+                Issuer = options1.ClientId!.ToString(),
+                Audience = options1.TokenEndpoint!.ToString(),
                 Expires = DateTime.UtcNow.AddMinutes(1),
                 SigningCredentials = GetSigningCredential(),
 
                 Claims = new Dictionary<string, object>
                 {
                     { JwtClaimTypes.JwtId, Guid.NewGuid().ToString() },
-                    { JwtClaimTypes.Subject, options1.ClientId! },
-                    { JwtClaimTypes.IssuedAt, DateTime.UtcNow.ToEpochTime() }
+                    { JwtClaimTypes.Subject, options.ClientId.ToString()! },
+                    { JwtClaimTypes.IssuedAt, DateTimeOffset.UtcNow.ToUnixTimeSeconds() }
                 },
 
                 AdditionalHeaderClaims = new Dictionary<string, object>


### PR DESCRIPTION
- Subject must be a string
- fix warning

DOC: https://docs.duendesoftware.com/accesstokenmanagement/advanced/client-assertions/