### PR TITLE
Document `SigninStateCookieName` option in SAML configuration

### DIFF
--- a/astro/src/content/docs/identityserver/saml/configuration.md
+++ b/astro/src/content/docs/identityserver/saml/configuration.md
@@ -72,6 +72,9 @@ Available options:
 * **`MaxRelayStateLength`**
   Maximum length (in UTF-8 bytes) of the RelayState parameter. Defaults to 80.
 
+* **`SigninStateCookieName`**
+  Name of the cookie used to store the SAML sign-in state identifier. Defaults to `__IdsSvr_SamlSigninState`.
+
 * **`UserInteraction`**
   Configures SAML endpoint paths. See below.
 


### PR DESCRIPTION
Probably second alpha drop?