### PR TITLE
Add v8 changes from products repo and include IdentityServer4 to v8 upgrade guide

### DIFF
--- a/astro/src/content/docs/identityserver/upgrades/identityserver4-to-duende-identityserver-v8.mdx
+++ b/astro/src/content/docs/identityserver/upgrades/identityserver4-to-duende-identityserver-v8.mdx
@@ -1,0 +1,649 @@
+---
+title: "IdentityServer4 to Duende IdentityServer v8.0"
+sidebar:
+  order: 139
+  label: IdentityServer4 → v8.0
+---
+
+import { Code } from "@astrojs/starlight/components";
+import { Steps } from "@astrojs/starlight/components";
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+:::note[Prerelease version]
+IdentityServer v8.0 is currently a prerelease version.
+:::
+
+This upgrade guide covers upgrading from IdentityServer4 to Duende IdentityServer v8.0.
+IdentityServer4 reached its end of life (EOL) on December 13, 2022. It is strongly advised to migrate to Duende IdentityServer.
+
+:::tip[IdentityServer4 Migration Analysis]
+Start your upgrade with this step-by-step migration guide, and use our automated [IdentityServer4 Migration Analysis Tool](/identityserver/upgrades/identityserver4-upgrade-analysis.mdx)
+tool to help identify important aspects of your upgrade to Duende IdentityServer.
+
+We also offer a [free IdentityServer4 upgrade assessment](https://duendesoftware.com/upgrade-identityserver4) to walk you through your upgrade path.
+:::
+
+Depending on your current version of IdentityServer4, different steps may be required.
+You can determine the version of IdentityServer4 by running the `dotnet list` command at the root of your IdentityServer host project, or using NuGet tooling in Visual Studio or JetBrains Rider.
+
+{/* prettier-ignore */}
+<Tabs syncKey="operatingSystem">
+  <TabItem label="Windows">
+    <Code
+      code={'dotnet list package | sls "IdentityServer4"'}
+      lang="bash"
+      title="Terminal"
+    />
+  </TabItem>
+  <TabItem label="macOS / Linux">
+    <Code
+      code={"dotnet list package | grep IdentityServer4"}
+      lang="bash"
+      title="Terminal"
+    />
+  </TabItem>
+</Tabs>
+
+This command will print a list of packages you're using in your solution, along with their version.
+
+```bash title="Output"
+   > IdentityServer4                            3.1.4       3.1.4
+   > IdentityServer4.EntityFramework            3.1.4       3.1.4
+```
+
+Depending on the package version shown, your next steps will be different:
+
+- If you are on IdentityServer v3.x, we recommend first [upgrading to IdentityServer4 v4.x](#identityserver4-v3x-to-identityserver-v4x), and then to [Duende IdentityServer](#identityserver4-v4x-to-duende-identityserver). The configuration object model changed between the two major versions of IdentityServer4, and we recommend upgrading step-by-step.
+- If you are on IdentityServer v4.x, you can immediately [upgrade to Duende IdentityServer](#identityserver4-v4x-to-duende-identityserver).
+
+## IdentityServer4 UI Templates
+
+:::note
+Check your current host project's UI elements against the latest templates in **[`Duende.Templates`](/identityserver/overview/packaging.mdx)** to ensure
+you're using the latest recommendations and best practices.
+:::
+
+IdentityServer has always been a framework that championed customization and making the implementation your own,
+and we treat templates as a starting point in your journey to implementing an OIDC and OAuth server.
+
+During the development of IdentityServer4, the UI templates saw several changes between the years of **2018** to **2021**.
+
+We recommend two approaches to upgrading your UI elements of your IdentityServer host project:
+
+- Start with the latest templates and port your customizations to the new templates.
+- Use a code comparison tool to identify the changes you need to make to your templates.
+
+The first approach is the easiest, but it requires you to make changes to your project.
+The second approach is more involved, but it allows you to make changes to your project in a more controlled manner.
+
+## IdentityServer4 v3.x to IdentityServer v4.x
+
+The most straightforward upgrade path is to first update to the latest version of IdentityServer4 v4, and then continue to the latest Duende IdentityServer.
+
+:::tip[Sample project]
+We have a [sample project available on GitHub](https://github.com/DuendeSoftware/UpgradeSample-IdentityServer4-v3), which contains database migration scripts for these changes.
+:::
+
+Between IdentityServer4 v3.x and v4.x, the configuration object model was updated:
+
+- The relation between `ApiResources` and `ApiScopes` was changed from parent-child to many-to-many.
+- A number of configuration types were renamed:
+  - `ApiProperties` to `ApiResourceProperties`
+  - `ApiSecrets` to `ApiResourceSecrets`
+  - `IdentityClaims` to `IdentityResourceClaims`
+  - `IdentityProperties` to `IdentityResourceProperties`
+  - `ApiScopes` to `ApiResourceScopes`
+
+IdentityServer4 projects that use the `IdentityServer4.EntityFramework` package or implement their own stores will need to update their code and/or database to reflect these changes.
+
+:::caution
+Database changes will need to be done using a custom migration script, as using the default Entity Framework Core migration will result in data loss. We'll look at this later in this upgrade guide.
+:::
+
+### Step 1: Update NuGet Packages
+
+Update the IdentityServer4 dependencies in your IdentityServer host project to version `4.1.2`.
+
+```diff lang="xml" title=".csproj"
+- <PackageReference Include="IdentityServer4" Version="3.1.4" />
++ <PackageReference Include="IdentityServer4" Version="4.1.2" />
+```
+
+Make sure to change the version number for all IdentityServer4 packages, including `IdentityServer4.EntityFramework` and `IdentityServer4.AspNetIdentity`.
+
+### Step 2: Make Code Changes
+
+It's likely some code changes will be required, especially when using the IdentityServer UI templates.
+[Visual Studio](https://visualstudio.microsoft.com/) and [JetBrains Rider](https://www.jetbrains.com/rider/) provide great code completion that can be of help here.
+
+:::tip[Use the new Razor Pages templates]
+If you have not made customizations to the IdentityServer UI templates, consider replacing them with the new Razor Pages-based templates as shown in [the quickstart tutorials](/identityserver/quickstarts/0-overview.md).
+:::
+
+A couple of compilation errors and required changes you may encounter:
+
+* When configuring scopes in memory, you need to register the scopes on startup.
+
+  ```diff lang="csharp" title="Program.cs"
+  builder.Services.AddIdentityServer()
+      .AddInMemory...
+  +    .AddInMemoryApiScopes(Config.ApiScopes)
+    ```
+
+* The `IIdentityServerInteractionService.GetAllUserConsentsAsync` method was renamed to `IIdentityServerInteractionService.GetAllUserGrantsAsync`
+* `ConsentResponse.Denied` was removed. Use the `DenyAuthorizationAsync` instead:
+
+  ```diff lang="csharp" title="*.cs"
+  - await _interaction.GrantConsentAsync(context, ConsentResponse.Denied);
+  + await _interaction.DenyAuthorizationAsync(context, AuthorizationError.AccessDenied);
+  ```
+
+* No overload method `SignInAsync` takes N arguments. The `HttpContext.SignInAsync` signature changed:
+
+  ```diff lang="csharp" title="*.cs"
+  // issue authentication cookie with subject ID and username
+  - await HttpContext.SignInAsync(user.SubjectId, user.Username, props);
+  + var isuser = new IdentityServerUser(user.SubjectId)
+  + {
+  +     DisplayName = user.Username
+  + };
+  +
+  + await HttpContext.SignInAsync(isuser, props);
+  ```
+
+* `AuthorizationRequest` doesn't contain definition for `ClientId`:
+
+  ```diff lang="csharp" title="*.cs"
+  - var client = await _clientStore.FindEnabledClientByIdAsync(request.ClientId);
+  + var client = await _clientStore.FindEnabledClientByIdAsync(request.Client.ClientId);
+  ```
+
+* `AuthorizationRequest` doesn't contain definition for `ScopesRequested`:
+
+  ```diff lang="csharp" title="*.cs"
+  - var resources = await _resourceStore.FindEnabledResourcesByScopeAsync(request.ScopesRequested);
+  + var resources = await _resourceStore.FindEnabledResourcesByScopeAsync(request.ValidatedResources.RawScopeValues);
+  ```
+
+* `IClientStore` doesn't contain definition for `IsPkceClientAsync`:
+
+  ```diff lang="csharp" title="*.cs"
+  - if (await _clientStore.IsPkceClientAsync(context.ClientId))
+  + if (context.IsNativeClient())
+  ```
+
+* The name `ProcessLoginCallbackForOidc` doesn't exist in the current context:
+
+  ```diff lang="csharp" title="*.cs"
+  - ProcessLoginCallbackForOidc(result, additionalLocalClaims, localSignInProps);
+  - ProcessLoginCallbackForWsFed(result, additionalLocalClaims, localSignInProps);
+  - ProcessLoginCallbackForSaml2p(result, additionalLocalClaims, localSignInProps);
+  + ProcessLoginCallback(result, additionalLocalClaims, localSignInProps);
+  ```
+
+* `ConsentResponse` does not contain a definition for `ScopesConsented`:
+
+  ```diff lang="csharp" title="*.cs"
+  grantedConsent = new ConsentResponse
+  {
+      RememberConsent = model.RememberConsent,
+  -    ScopesConsented = scopes.ToArray()
+  +    ScopesValuesConsented = scopes.ToArray()
+  };
+  ```
+
+### Step 3: Update Database Schema
+
+If you are using the `IdentityServer4.EntityFramework` package to store configuration and operational data in a [database](/identityserver/data/index.md),
+you'll need to create two database migrations that update the database schema.
+Note that you may want to change the database migration paths in the examples below to reflect your project structure.
+
+:::caution
+Make sure to verify the database migrations as part of your IdentityServer4 upgrade, to ensure all configuration and operational data remains in place.
+:::
+
+For the operational data, you can create and apply an Entity Framework Core migration that targets the `PersistedGrantDbContext` database context.
+
+{/* prettier-ignore */}
+<Steps>
+
+1. Create the migration:
+
+   ```bash title="Terminal"
+   dotnet ef migrations add Grants_v4 -c PersistedGrantDbContext -o Migrations/PersistedGrantDb
+   ```
+
+2. Apply the migration to your database:
+
+   ```bash title="Terminal"
+   dotnet ef database update -c PersistedGrantDbContext
+   ```
+
+</Steps>
+
+For your configuration data, the conversation from the old schema to the new will need to be performed by applying a custom SQL script.
+We'll start with creating a migration that targets the `ConfigurationDbContext` database context:
+
+{/* prettier-ignore */}
+<Steps>
+
+1. Create the migration:
+
+   ```bash title="Terminal"
+   dotnet ef migrations add Config_v4 -c ConfigurationDbContext -o Migrations/ConfigurationDb
+   ```
+
+   You will see a message _"An operation was scaffolded that may result in the loss of data. Please review the migration for accuracy."_ in the output.
+   To avoid data loss, the migration will need to be updated.
+
+2. To ensure no data is lost, make sure to include the [`ConfigurationDb_v4_delta.sql`](https://github.com/DuendeArchive/UpgradeSample-IdentityServer4-v3/blob/main/IdentityServerMigrationSample/ConfigurationDb_v4_delta.sql)
+   script in your project.
+
+   You can add the script as an embedded resource by updating the `.csproj` file:
+
+   ```xml title=".csproj"
+   <ItemGroup>
+       <EmbeddedResource Include="ConfigurationDb_v4_delta.sql" />
+   </ItemGroup>
+   ```
+
+   :::note[Update the SQL script for your database type]
+   The `ConfigurationDb_v4_delta.sql` file assumes you are using SQL Server. If a different database server type is used for your IdentityServer host, you'll need to update the SQL script to use the correct syntax.
+   :::
+
+3. Modify the migration class that was just created and replace it with the following code:
+
+   ```csharp title="Config_v4.cs"
+   using System.IO;
+   using Microsoft.EntityFrameworkCore.Migrations;
+
+   namespace IdentityServerMigrationSample.Migrations.ConfigurationDb
+   {
+       public partial class Config_v4 : Migration
+       {
+           protected override void Up(MigrationBuilder migrationBuilder)
+           {
+               var assembly = typeof(Program).Assembly;
+
+               using (var s = assembly.GetManifestResourceStream("IdentityServerMigrationSample.ConfigurationDb_v4_delta.sql"))
+               {
+                   using (StreamReader sr = new StreamReader(s))
+                   {
+                       var sql = sr.ReadToEnd();
+                       migrationBuilder.Sql(sql);
+                   }
+               }
+           }
+
+           protected override void Down(MigrationBuilder migrationBuilder)
+           {
+           }
+       }
+   }
+   ```
+
+4. Apply the migration to your database:
+
+   ```bash title="Terminal"
+   dotnet ef database update -c ConfigurationDbContext
+   ```
+
+</Steps>
+
+Your database schema should now be updated. You can verify all data is intact, using the [queries outlined in `query_v4.sql`](https://github.com/DuendeArchive/UpgradeSample-IdentityServer4-v3/blob/main/IdentityServerMigrationSample/query_v4.sql).
+These queries may return a lot of data, consider adding a `TOP` clause if you want to only sample some of the migrated data.
+
+<details>
+    <summary>View SQL queries to validate migration succeeded</summary>
+
+    ```sql title="query_v4.sql"
+    SELECT * FROM __EFMigrationsHistory
+
+    SELECT * FROM ApiResourceClaims
+    SELECT * FROM ApiResourceProperties
+    SELECT * FROM ApiResources
+    SELECT * FROM ApiResourceScopes
+    SELECT * FROM ApiResourceSecrets
+
+    SELECT * FROM ApiScopeClaims
+    SELECT * FROM ApiScopes
+    SELECT * FROM ApiScopeProperties
+
+    SELECT * FROM ClientClaims
+    SELECT * FROM ClientCorsOrigins
+    SELECT * FROM ClientGrantTypes
+    SELECT * FROM ClientIdPRestrictions
+    SELECT * FROM ClientPostLogoutRedirectUris
+    SELECT * FROM ClientProperties
+    SELECT * FROM ClientRedirectUris
+    SELECT * FROM Clients
+    SELECT * FROM ClientScopes
+    SELECT * FROM ClientSecrets
+
+    SELECT * FROM DeviceCodes
+    SELECT * FROM PersistedGrants
+
+    SELECT * FROM IdentityResourceClaims
+    SELECT * FROM IdentityResourceProperties
+    SELECT * FROM IdentityResources
+    ```
+
+</details>
+
+With the migration to IdentityServer v4.x complete, you can [upgrade to Duende IdentityServer](#identityserver4-v4x-to-duende-identityserver).
+
+## IdentityServer4 v4.x to Duende IdentityServer
+
+Upgrading from IdentityServer4 v4.x to Duende IdentityServer v8.0 consists of several tasks: updating the target .NET version, updating NuGet packages, making code changes, and performing database schema migrations.
+
+### Step 1: Update the .NET Version
+
+Duende IdentityServer v8.0 targets .NET 10 only. Update the IdentityServer target framework:
+
+```diff lang="xml" title=".csproj"
+- <TargetFramework>netcoreapp3.1</TargetFramework>
++ <TargetFramework>net10.0</TargetFramework>
+```
+
+Some of your project dependencies may need updating as part of changing the target framework.
+For example, `Microsoft.EntityFrameworkCore.SqlServer` and `Microsoft.AspNetCore.Authentication.Google` will need to be updated to the version matching your target framework.
+
+:::tip[Updating .NET and ASP.NET Core]
+Depending on the amount of customization in your IdentityServer4 host and UI templates, there may be code changes needed based on updates to .NET and ASP.NET Core.
+Make sure to consult the ASP.NET Core migration guides provided by Microsoft.
+
+<details>
+    <summary>Breaking changes in .NET</summary>
+
+    * [Breaking changes in .NET Core 3.1](https://learn.microsoft.com/en-us/dotnet/core/compatibility/3.1)
+    * [Breaking changes in .NET 5](https://learn.microsoft.com/en-us/dotnet/core/compatibility/5.0)
+    * [Breaking changes in .NET 6](https://learn.microsoft.com/en-us/dotnet/core/compatibility/6.0)
+    * [Breaking changes in .NET 7](https://learn.microsoft.com/en-us/dotnet/core/compatibility/7.0)
+    * [Breaking changes in .NET 8](https://learn.microsoft.com/en-us/dotnet/core/compatibility/8.0)
+    * [Breaking changes in .NET 9](https://learn.microsoft.com/en-us/dotnet/core/compatibility/9.0)
+    * [Breaking changes in .NET 10](https://learn.microsoft.com/en-us/dotnet/core/compatibility/10.0)
+
+</details>
+
+<details>
+    <summary>ASP.NET Core migration guides</summary>
+
+    * [Migrate from ASP.NET Core 3.1 to 6.0](https://learn.microsoft.com/en-us/aspnet/core/migration/31-to-60)
+    * [Migrate from ASP.NET Core 6.0 to 7.0](https://learn.microsoft.com/en-us/aspnet/core/migration/60-70)
+    * [Migrate from ASP.NET Core 7.0 to 8.0](https://learn.microsoft.com/en-us/aspnet/core/migration/70-80)
+    * [Migrate from ASP.NET Core 8.0 to 9.0](https://learn.microsoft.com/en-us/aspnet/core/migration/80-90)
+    * [Migrate from ASP.NET Core 9.0 to 10.0](https://learn.microsoft.com/en-us/aspnet/core/migration/90-to-100)
+
+</details>
+:::
+
+### Step 2: Update NuGet Packages
+
+Update the IdentityServer4 dependencies in your IdentityServer host project to Duende IdentityServer v8.0.
+
+```diff lang="xml" title=".csproj"
+- <PackageReference Include="IdentityServer4" Version="4.1.2" />
++ <PackageReference Include="Duende.IdentityServer" Version="8.0.0-*" />
+```
+
+You'll need to make a similar change for all IdentityServer4 packages, including `IdentityServer4.EntityFramework` and `IdentityServer4.AspNetIdentity`. For example:
+
+```diff lang="xml" title=".csproj"
+- <PackageReference Include="IdentityServer4.EntityFramework" Version="4.1.2" />
++ <PackageReference Include="Duende.IdentityServer.EntityFramework" Version="8.0.0-*" />
+```
+
+The IdentityModel package was renamed to Duende IdentityModel and needs updating if you reference it directly:
+
+```diff lang="xml" title=".csproj"
+- <PackageReference Include="IdentityModel" Version="x.y.z" />
++ <PackageReference Include="Duende.IdentityModel" Version="8.0.0" />
+```
+
+### Step 3: Update Namespaces
+
+In your project source code, replace all `IdentityServer4` namespace usages with `Duende.IdentityServer`:
+
+```diff lang="csharp" title="*.cs"
+- using IdentityServer4;
+- using IdentityServer4.Models;
++ using Duende.IdentityServer;
++ using Duende.IdentityServer.Models;
+```
+
+Replace all `IdentityModel` namespace usages with `Duende.IdentityModel`:
+
+```diff lang="csharp" title="*.cs"
+- using IdentityModel;
++ using Duende.IdentityModel;
+```
+
+If you're using fully-qualified names in your code, those will need to be updated as well.
+
+### Step 4: Remove AddDeveloperSigningCredential :badge[Optional]
+
+In your application startup code, typically found in the `ConfigureServices` method in `Startup.cs`, consider removing `AddDeveloperSigningCredential`.
+
+You can use Duende IdentityServer's built-in [manual or automatic key management](/identityserver/fundamentals/key-management.md) instead.
+
+### Step 5: Update Database Schema
+
+Whether you are using a [database](/identityserver/data/index.md) or a [custom store implementation](/identityserver/reference/stores/index.md) for your configuration and operational data, you'll need to make some changes.
+The exact steps involved in updating your data store will depend on your implementation details.
+
+In this section, we'll look at updating the database schema based on the stores provided in the `Duende.IdentityServer.EntityFramework` package:
+
+- Create a new `Keys` table for the automatic key management feature in the operational database.
+- Create a new `RequireResourceIndicator` boolean column on the `ApiResources` table in the configuration database.
+- Create a new index on the `ConsumedTime` column in the `PersistedGrants` table ([more details](https://github.com/DuendeSoftware/products/pull/84)).
+- Create a new table called `IdentityProviders` for storing the OIDC provider details ([more details](https://github.com/DuendeSoftware/products/pull/188)).
+- Add missing columns for created, updated, etc. to EF entities ([more details](https://github.com/DuendeSoftware/products/pull/356)).
+- Add unique constraints to EF tables where duplicate records are not allowed ([more details](https://github.com/DuendeSoftware/products/pull/355)).
+- The server-side sessions feature requires a new table ([more details](https://github.com/DuendeSoftware/products/pull/743)).
+- The session coordination feature adds a column to the `Clients` table ([more details](https://github.com/DuendeSoftware/products/pull/820)).
+- Improve primary keys on the persisted grants table ([more details](https://github.com/DuendeSoftware/products/pull/793)).
+- Add new properties to the [`Duende.IdentityServer.Models.Client` model](/identityserver/reference/models/client.md):
+
+  - `InitiateLoginUri` is a nullable string used for Third Party Initiated Login.
+  - `RequireDPoP` is a non-nullable boolean flag that controls if a client is required to use [DPoP](/identityserver/tokens/pop.md).
+  - `DPoPValidationMode` is a non-nullable column that controls the DPoP validation mechanism. Existing clients that aren't using DPoP can set its value to `0`.
+  - `DPoPClockSkew` is a non-nullable timespan that controls how much clock skew is allowed for a particular DPoP client. Existing clients that aren't using DPoP can set its value to a timespan of length ``0.
+
+- Two new properties have been added to the `Client` model:
+  - `Client.RequirePushedAuthorization` is a new boolean property that controls if this client requires [pushed authorization requests (PAR)](/identityserver/tokens/par.md). It is safe to initialize this column to `false` for existing clients, which will mean that the global PAR configuration will be used.
+  - `Client.PushedAuthorizationLifetime` is a new nullable integer property that controls the lifetime of pushed
+    authorization requests (in seconds) for a client. It is safe to initialize this column to `null` for existing clients, which means the global value is used.
+- A new `PushedAuthorizationRequest` table has been added to store pushed authorization requests.
+- If you are using the SAML 2.0 Identity Provider feature, five new tables are required: `SamlServiceProviders`, `SamlServiceProviderAssertionConsumerServices`, `SamlServiceProviderSigningCertificates`, `SamlServiceProviderEncryptionCertificates`, and `SamlServiceProviderClaimMappings`.
+
+You'll need to create two database migrations that update the database schema: one that targets the `PersistedGrantDbContext` (for operational data), and one that targets the `ConfigurationDbContext` (for configuration data).
+Note that you may want to change the database migration paths in the examples below to match your project structure.
+
+{/* prettier-ignore */}
+<Steps>
+
+1. Create the migrations for the operational and configuration database context:
+
+   ```bash title="Terminal"
+   dotnet ef migrations add UpdateToDuende_v8_0 -c PersistedGrantDbContext -o Data/Migrations/IdentityServer/PersistedGrantDb
+   dotnet ef migrations add UpdateToDuende_v8_0 -c ConfigurationDbContext -o Data/Migrations/IdentityServer/ConfigurationDb
+   ```
+
+   :::note
+   You may see a warning _"An operation was scaffolded that may result in the loss of data. Please review the migration for accuracy."_.
+   The column length for redirect URIs (for both login and logout) was reduced from 2000 to 400 to overcome database index size limits.
+   Unless you are using redirect URIs greater than 400 characters, this should not affect you.
+   :::
+
+2. Apply the migrations to your database:
+
+   ```bash title="Terminal"
+   dotnet ef database update -c PersistedGrantDbContext
+   dotnet ef database update -c ConfigurationDbContext
+   ```
+
+</Steps>
+
+#### Custom Store Implementations
+
+In v8.0, all store and service interface methods now require a `CancellationToken ct` parameter. If you have custom implementations of any IdentityServer store or service interface (such as `IClientStore`, `IResourceStore`, `IPersistedGrantStore`, etc.), you must update every async method signature to include the `CancellationToken ct` parameter.
+
+Additionally, `IClientStore` now includes a new required method:
+
+```csharp
+IAsyncEnumerable<Client> GetAllClientsAsync(CancellationToken ct);
+```
+
+All custom `IClientStore` implementations must add this method. It is used by the conformance report
+and configuration validation features. Return an async enumerable of all configured clients.
+
+### Step 6: Migrate Signing Keys :badge[Optional]
+
+:::tip[Determine if you are using a custom signing key]
+In `Startup.cs`, look for a call to `AddSigningCredential()` that uses key material such as an `X509Certificate2`.
+:::
+
+Client apps and APIs typically cache the key material published from IdentityServer's discovery document.
+When upgrading, consider how those applications will handle an upgraded token server with a new and different signing key.
+
+- If you can restart all client apps and APIs that depend on your current signing key, you can remove the old signing key and start to use automatic key management. A restart reloads the discovery document and the new signing key.
+- If you can not restart client apps and APIs, check the [manual and automatic key rotation topics](/identityserver/fundamentals/key-management.md#manual-key-rotation) to learn how to announce new signing key material while still supporting the old signing key for a period of time.
+
+If your IdentityServer4 implementation is using a signing key, consider using [automatic key management](/identityserver/fundamentals/key-management.md).
+
+:::note
+This feature is part of the [Duende IdentityServer Business and Enterprise Edition](https://duendesoftware.com/products/identityserver).
+:::
+
+### Step 7: Verify Data Protection Configuration :badge[Optional]
+
+Duende IdentityServer depends on [ASP.NET Data Protection](/identityserver/deployment/index.md#aspnet-core-data-protection) to encrypt and sign data using keys managed by ASP.NET.
+
+As part of your migration, verify the application name is set in your Data Protection configuration:
+
+```csharp title="Program.cs" {4}
+builder.Services.AddDataProtection()
+    .PersistKeysTo...()
+    .ProtectKeysWith...()
+    .SetApplicationName("IdentityServerXYZ");
+```
+
+If an application name is set, you can skip this section.
+
+Data Protection keys are isolated by application name, to prevent multiple applications from sharing encryption keys.
+
+If no application name is configured, ASP.NET Data Protection uses the content root path of the IdentityServer host as the application name.
+As a consequence, if your content root path changes, the default settings for data protection will prevent you from using your old data protection keys.
+
+Between different .NET versions, this default setting has changed:
+
+| Version  | Default                                                        |
+|----------|----------------------------------------------------------------|
+| .NET 3.1 | Content root path without directory separator suffix           |
+| .NET 5   | Content root path without directory separator suffix           |
+| .NET 6   | Content root path (normalized with directory separator suffix) |
+| .NET 7+  | Content root path without directory separator suffix           |
+
+Your application name might change (and existing data protection keys may become invalid) if you're currently targeting .NET 6 and don't have the application name set explicitly.
+
+To prevent this from happening, you can explicitly set the application name to the content root path without the directory separator character, as [documented on Microsoft Learn](https://learn.microsoft.com/en-us/aspnet/core/security/data-protection/configuration/overview?view=aspnetcore-6.0#setapplicationname).
+
+:::tip[Getting the current application name]
+In your current (pre-upgraded) IdentityServer version, you can query the application name used and set it explicitly in your upgraded deployment:
+
+```csharp
+// ...
+
+var app = builder.Build();
+
+// ...
+var applicationName = "";
+var applicationDiscriminatorService = app.Services.GetService<IApplicationDiscriminator>();
+if (applicationDiscriminatorService != null)
+{
+    applicationName = applicationDiscriminatorService.Discriminator;
+}
+var dataProtectionOptions = app.Services.GetService<IOptions<DataProtectionOptions>>();
+if (dataProtectionOptions != null && dataProtectionOptions.Value.ApplicationDiscriminator != null)
+{
+    dataProtectionApplicationDiscriminator = dataProtectionOptions.Value.ApplicationDiscriminator;
+}
+            
+// applicationName is now the (auto-generated?) application name
+// - you can use its value in your upgraded IdentityServer version
+```
+
+:::
+
+### Step 8: Validate Your Deployment
+
+Congratulations! Your upgrade is complete.
+
+Make sure to validate and test your Duende IdentityServer is working as expected, and check integrations with your client applications and APIs.
+
+:::note
+IdentityServer is free for development, testing, and personal projects, but production use
+requires a [license](https://duendesoftware.com/products/identityserver).
+:::
+
+## Breaking Changes
+
+Duende IdentityServer is a Software Development Kit (SDK) that you can use to build your own identity and access management solutions (IAM).
+Being an SDK, there is a lot of potential for customization during the implementation. Depending on your specific project, breaking changes might affect your use of IdentityServer.
+
+As part of your upgrade from IdentityServer4 to Duende IdentityServer v8.0, we recommend reviewing these breaking changes to understand if any of them affect you.
+
+### Changes Introduced in Earlier Duende IdentityServer Versions
+
+These breaking changes were introduced in Duende IdentityServer versions prior to v8.0 and apply when upgrading directly from IdentityServer4:
+
+- [Quickstart UI updated to use Razor Pages](https://github.com/DuendeSoftware/IdentityServer/pull/263)
+- [Addition of cancellation token to store APIs](https://github.com/DuendeSoftware/IdentityServer/pull/405)
+- [Store DbContext constructors to support DbContext pooling](https://github.com/DuendeSoftware/IdentityServer/pull/260)
+- [CustomRedirectResult returnUrl changes](https://github.com/DuendeSoftware/IdentityServer/pull/358)
+- [Add missing columns for created, updated, etc. to EF entities](https://github.com/DuendeSoftware/IdentityServer/pull/356)
+- [Add unique constraints to EF tables where duplicate records not allowed](https://github.com/DuendeSoftware/IdentityServer/pull/355)
+- [Added grant handle versioning suffix](https://github.com/DuendeSoftware/IdentityServer/pull/404)
+- [Many HttpContext extensions marked obsolete](https://github.com/DuendeSoftware/IdentityServer/pull/414)
+- [New APIs to the ICache interface](https://github.com/DuendeSoftware/IdentityServer/pull/421)
+- [New Client columns for CIBA](https://github.com/DuendeSoftware/IdentityServer/pull/498)
+- [openid no longer implicit in OidcProvider scope collection](https://github.com/DuendeSoftware/IdentityServer/pull/507)
+- [JwtRequestValidator signature changes](https://github.com/DuendeSoftware/IdentityServer/pull/537)
+- [Changes in AppAuth URL validator for logout](https://github.com/DuendeSoftware/IdentityServer/pull/619)
+- [Use of EmailClaimType option in ASP.NET Identity integration](https://github.com/DuendeSoftware/IdentityServer/pull/625)
+- `ClientConfigurationStore` now uses `IConfigurationDbContext` to allow for customization. If you have a customized Entity Framework Core-based store, you may need to update your constructors.
+- [The `SendLogoutNotificationAsync` method has been removed from the `DefaultBackChannelLogoutService` class](/identityserver/upgrades/v7_2-to-v7_3.md#the-sendlogoutnotificationasync-method-has-been-removed-from-the-defaultbackchannellogoutservice-class)
+- [Client `Secret` is now required for Clients with `ClientCredentials` grant](/identityserver/upgrades/v7_2-to-v7_3.md#client-secret-is-now-required-for-clients-with-clientcredentials-grant)
+
+### Changes Introduced in v8.0
+
+The following breaking changes are new in Duende IdentityServer v8.0. For full details and code examples, see the [v7.4 to v8.0 upgrade guide](/identityserver/upgrades/v7_4-to-v8_0.md).
+
+- **`ICache<T>` / `DefaultCache<T>` replaced by `HybridCache`.** Custom `ICache<T>` implementations must be replaced. Built-in caching users are unaffected.
+- **`IClock` replaced by `TimeProvider`.** Replace `IClock` with `System.TimeProvider` and `clock.UtcNow` with `timeProvider.GetUtcNow()`.
+- **`CancellationToken` now required on all interface methods.** All store and service interface async methods require a `CancellationToken ct` parameter. Update all custom implementations.
+- **`ICancellationTokenProvider` removed.** Use the `CancellationToken` passed directly to interface methods instead.
+- **HTTP 303 redirects now unconditional.** POST endpoint redirects always use HTTP 303 per [FAPI 2.0](https://openid.net/specs/fapi-security-profile-2_0.html).
+- **`IClientStore.GetAllClientsAsync` now required.** New method returning `IAsyncEnumerable<Client>`. All custom implementations must add it.
+- **`IRefreshTokenService` method signatures changed.** `CreateRefreshTokenAsync` and `UpdateRefreshTokenAsync` now accept dedicated request objects instead of individual parameters.
+- **Nullable reference types enabled across all assemblies.** Custom implementations may see new compiler warnings about null handling.
+- **`response_mode` validated earlier in the authorization pipeline.** Error responses now use the client's requested `response_mode`.
+- **DPoP type names corrected.** `DPoPProofValidatonContext` and `DPoPProofValidatonResult` renamed to fix the `Validaton` typo.
+- **`PersistedGrantFilter` collection properties are now non-nullable.** `ClientIds` and `Types` default to empty collections. Replace null checks with count checks.
+- **`IEnumerable<T>` return types changed to `IReadOnlyCollection<T>`.** Several interface methods updated. Custom implementations must update return types; callers that only enumerate are unaffected.
+- **`IUserSession`: new SAML session methods.** Three new methods for SAML 2.0 session tracking. Custom implementations must add them (no-op implementations are fine if not using SAML).
+- **DPoP changes in JwtBearer package.** `DPoPExtensions` replaced by `DPoPServiceCollectionExtensions`, with new properties for proof token expiration modes.
+
+## New Features in v8.0
+
+### SAML 2.0 Identity Provider
+
+IdentityServer 8.0 adds support for acting as a SAML 2.0 Identity Provider, enabling integration
+with enterprise applications and legacy systems that use SAML. See the
+[SAML 2.0 documentation](/identityserver/saml/) for setup and configuration details.
+
+### Conformance Report
+
+A new `Duende.IdentityServer.ConformanceReport` package generates an HTML report assessing your
+IdentityServer deployment against OAuth 2.1 and FAPI 2.0 specifications. See the
+[Conformance Report documentation](/identityserver/diagnostics/conformance-report/) for details.

--- a/astro/src/content/docs/identityserver/upgrades/index.md
+++ b/astro/src/content/docs/identityserver/upgrades/index.md
@@ -22,6 +22,7 @@ IdentityServer v8.0 is currently a prerelease version.
 :::
 
 * [**IdentityServer v7.4 to v8.0**](/identityserver/upgrades/v7_4-to-v8_0.md)
+* [**IdentityServer4 to Duende IdentityServer v8**](/identityserver/upgrades/identityserver4-to-duende-identityserver-v8.mdx)
 
 ## Upgrading to v7.0
 

--- a/astro/src/content/docs/identityserver/upgrades/index.md
+++ b/astro/src/content/docs/identityserver/upgrades/index.md
@@ -15,43 +15,39 @@ changes. Some updates contain changes to the stores used by IdentityServer that 
 schema updates. If you are using our Entity Framework based stores we recommend using Entity Framework
 Migrations.
 
-## Upgrading from version 7.4 to 8.0
+## Upgrading to v8.0
 
 :::note[Prerelease version]
 IdentityServer v8.0 is currently a prerelease version.
 :::
 
-See [IdentityServer v7.4 to v8.0](/identityserver/upgrades/v7_4-to-v8_0/).
+* [**IdentityServer v7.4 to v8.0**](/identityserver/upgrades/v7_4-to-v8_0.md)
 
-## Upgrading from version 7.3 to 7.4
+## Upgrading to v7.0
 
-See [IdentityServer v7.3 to v7.4](/identityserver/upgrades/v7_3-to-v7_4.md).
+* [**IdentityServer v7.1 to v7.2**](/identityserver/upgrades/v7_3-to-v7_4.md)
+* [**IdentityServer v7.2 to v7.3**](/identityserver/upgrades/v7_2-to-v7_3.md)
+* [**IdentityServer v7.1 to v7.2**](/identityserver/upgrades/v7_1-to-v7_2.md)
+* **IdentityServer v7.0 to v7.1**:
+  
+  IdentityServer v7.1 includes support for **.NET 9** and many other smaller fixes and
+  enhancements. There are no schema changes needed for IdentityServer 7.1. There are two changes that may require small
+  code changes for a minority of users:
+  
+  - _`IdentityModel`_ package renamed to _`Duende.IdentityModel`_ which may require code updates to referenced namespaces
+    and types.
+  - `ClientConfigurationStore` now uses `IConfigurationDbContext`.
 
-## Upgrading from version 7.2 to 7.3
+* [**IdentityServer4 to Duende IdentityServer v7**](/identityserver/upgrades/identityserver4-to-duende-identityserver-v7.mdx)
 
-See [IdentityServer v7.2 to v7.3](/identityserver/upgrades/v7_2-to-v7_3.md).
 
-## Upgrading from version 7.1 to 7.2
-
-See [IdentityServer v7.1 to v7.2](/identityserver/upgrades/v7_1-to-v7_2.md).
-
-## Upgrading from version 7.0 to 7.1
-
-IdentityServer v7.1 includes support for **.NET 9** and many other smaller fixes and
-enhancements. There are no schema changes needed for IdentityServer 7.1. There are two changes that may require small
-code changes for a minority of users:
-
-- _`IdentityModel`_ package renamed to _`Duende.IdentityModel`_ which may require code updates to referenced namespaces
-  and types.
-- `ClientConfigurationStore` now uses `IConfigurationDbContext`.
-
-## Upgrading from version 6 to version 7
+### Upgrading from version 6 to version 7
 
 We recommend upgrading incrementally through each minor version of the 6.x release before upgrading from
 6.3 to 7.0. At each step, update the NuGet package, apply database schema changes (if any), and check for
 breaking changes that affect your implementation.
 
-#### Upgrading from version 6.0
+##### Upgrading from version 6.0
 
 There are changes to the stores which requires database schema updates. If you use the Entity Framework
 based stores you need to apply the upgrade and database migrations
@@ -59,12 +55,12 @@ from [6.0 - 6.1](/identityserver/upgrades/v6_0-to-v6_1.md). Then
 continue with the [Upgrading from version 6.2](#upgrading-from-version-62) guide. If you are experienced with the Entity Framework
 Migrations Tooling you may also create a single migration from 6.0 to 7.0.
 
-#### Upgrading from version 6.1
+##### Upgrading from version 6.1
 
 There no schema changes or other breaking changes between 6.1 and 6.2.
 Follow the [Upgrading from version 6.2](#upgrading-from-version-62) guide.
 
-#### Upgrading from version 6.2
+##### Upgrading from version 6.2
 
 There are changes to the stores which requires database schema updates. If you use the Entity Framework
 based stores you need to apply the upgrade and database migrations
@@ -79,10 +75,6 @@ if any of them affect your implementation.
 
 Then continue with "Upgrading from version 6.3" below.
 
-#### Upgrading from version 6.3
+##### Upgrading from version 6.3
 
 Follow the [upgrade guide version 6.3 - 7.0](/identityserver/upgrades/v6_3-to-v7_0.md)
-
-## Upgrading from IdentityServer4 to Duende IdentityServer
-
-See [IdentityServer4 to Duende IdentityServer](/identityserver/upgrades/identityserver4-to-duende-identityserver-v7.mdx).

--- a/astro/src/content/docs/identityserver/upgrades/v7_3-to-v7_4.md
+++ b/astro/src/content/docs/identityserver/upgrades/v7_3-to-v7_4.md
@@ -32,17 +32,11 @@ target framework, which should be fully supported on both .NET 8 and .NET 9. .NE
 
 ## Step 1: Update NuGet package
 
-In your IdentityServer host project, update the version of the NuGet.
-For example, in your project file:
+In your IdentityServer host project, update the version of the NuGet packages.
 
-```xml
-<PackageReference Include="Duende.IdentityServer" Version="7.3.0" />
-```
-
-would change to:
-
-```xml
-<PackageReference Include="Duende.IdentityServer" Version="7.4.7" />
+```diff lang="xml" title=".csproj"
+- <PackageReference Include="Duende.IdentityServer" Version="7.3.0" />
++ <PackageReference Include="Duende.IdentityServer" Version="7.4.7" />
 ```
 
 ## Step 2: Breaking Changes

--- a/astro/src/content/docs/identityserver/upgrades/v7_4-to-v8_0.md
+++ b/astro/src/content/docs/identityserver/upgrades/v7_4-to-v8_0.md
@@ -1,7 +1,7 @@
 ---
 title: "Duende IdentityServer v7.4 to v8.0"
 description: Upgrade guide from IdentityServer v7.4 to v8.0 covering .NET 10, breaking changes, SAML 2.0 support, and new features.
-date: 2026-03-02
+date: 2026-04-28
 sidebar:
   order: 24
   label: v7.4 → v8.0
@@ -17,22 +17,18 @@ reporting, and many other fixes and enhancements.
 ## Step 1: Update .NET Version
 
 IdentityServer 8.0 targets .NET 10 only. In your IdentityServer host project, update the target
-framework. For example, in your project file:
+framework to .NET 10 (`net10.0`):
 
-```xml
-<TargetFramework>net8.0</TargetFramework>
+```diff lang="xml" title=".csproj"
+- <TargetFramework>net8.0</TargetFramework>
++ <TargetFramework>net10.0</TargetFramework>
 ```
 
 or
 
-```xml
-<TargetFramework>net9.0</TargetFramework>
-```
-
-would change to:
-
-```xml
-<TargetFramework>net10.0</TargetFramework>
+```diff lang="xml" title=".csproj"
+- <TargetFramework>net9.0</TargetFramework>
++ <TargetFramework>net10.0</TargetFramework>
 ```
 
 Any NuGet packages you use that target an older version of .NET should also be updated. For example,
@@ -42,17 +38,11 @@ may or may not be code changes from those updated dependencies.
 
 ## Step 2: Update NuGet Packages
 
-In your IdentityServer host project, update the version of the Duende.IdentityServer package.
-For example, in your project file:
+In your IdentityServer host project, update the version of the Duende IdentityServer package.
 
-```xml
-<PackageReference Include="Duende.IdentityServer" Version="7.4.0"/>
-```
-
-would change to:
-
-```xml
-<PackageReference Include="Duende.IdentityServer" Version="8.0.0-*"/>
+```diff lang="xml" title=".csproj"
+- <PackageReference Include="Duende.IdentityServer" Version="7.4.7" />
++ <PackageReference Include="Duende.IdentityServer" Version="8.0.0-*"/>
 ```
 
 If you use any of the other Duende.IdentityServer packages, update those as well:
@@ -69,7 +59,7 @@ If you are using the SAML 2.0 Identity Provider feature and the Entity Framework
 new tables are required to store SAML Service Provider configurations. Run the following migration
 commands to update your database schema:
 
-```bash
+```bash title="Terminal"
 dotnet ef migrations add Update_DuendeIdentityServer_v8_0 -c ConfigurationDbContext -o Migrations/ConfigurationDb
 dotnet ef database update -c ConfigurationDbContext
 ```
@@ -172,23 +162,47 @@ updates automatically when you run the EF migrations command above.
 
 ## Step 4: Breaking Changes
 
-### IClock Removed — Use TimeProvider
+### `ICache<T>` / `DefaultCache<T>` Replaced by `HybridCache`
+
+The custom `ICache<T>` interface and its default implementation `DefaultCache<T>` have been removed. Configuration-store caching now uses Microsoft's [`HybridCache`](https://learn.microsoft.com/en-us/aspnet/core/performance/caching/hybrid) from the `Microsoft.Extensions.Caching.Hybrid` package.
+
+**If you use the built-in caching (most applications):** No code changes are needed. The `AddInMemoryCaching()` and `AddXxxStoreCache<T>()` extension methods continue to work as before.
+
+**If you had a custom `ICache<T>` implementation:** You can no longer register a custom `ICache<T>`. Instead, customize the keyed `HybridCache` instance registered under `ServiceProviderKeys.ConfigurationStoreCache`. For example, to add a distributed cache backend:
+
+```csharp
+// Program.cs
+builder.Services.AddStackExchangeRedisCache(options =>
+{
+    options.Configuration = "localhost:6379";
+});
+
+builder.Services.AddIdentityServer()
+    .AddInMemoryCaching() // registers the keyed HybridCache
+    .AddClientStoreCache<YourCustomClientStore>();
+```
+
+`HybridCache` automatically uses any registered `IDistributedCache` as its L2 cache tier.
+
+**`CachingOptions.CacheLockTimeout` is now obsolete.** `HybridCache` provides built-in stampede protection, so the explicit lock timeout is no longer used for configuration-store caching. The property is retained (marked `[Obsolete]`) because it is still used internally by `KeyManager` for key-management locking.
+
+### `IClock` Replaced by `TimeProvider`
 
 `Duende.IdentityServer.IClock` has been removed. Replace it with the standard .NET
 `System.TimeProvider` (available since .NET 8).
 
-```csharp
-// Before (v7.x)
-public class MyService
-{
-    public MyService(IClock clock) { }
-}
+```diff lang="csharp" title="MyService.cs"
+- // Before (v7.x)0
+- public class MyService
+- {
+-     public MyService(IClock clock) { }
+- }
 
-// After (v8.0)
-public class MyService
-{
-    public MyService(TimeProvider timeProvider) { }
-}
++ // After (v8.0)
++ public class MyService
++ {
++     public MyService(TimeProvider timeProvider) { }
++ }
 ```
 
 To get the current time, use `timeProvider.GetUtcNow()` instead of `clock.UtcNow`.
@@ -201,29 +215,29 @@ been updated to accept `TimeProvider` in place of `IClock`.
 All store and service interfaces now include a `CancellationToken` parameter on every async method.
 The parameter name is `ct` (not `cancellationToken`).
 
-```csharp
-// Before (v7.x)
-public class MyClientStore : IClientStore
-{
-    public Task<Client?> FindClientByIdAsync(string clientId)
-    {
-        // ...
-    }
-}
+```diff lang="csharp" title="MyClientStore.cs"
+- // Before (v7.x)
+- public class MyClientStore : IClientStore
+- {
+-     public Task<Client?> FindClientByIdAsync(string clientId)
+-     {
+-         // ...
+-     }
+- }
 
-// After (v8.0)
-public class MyClientStore : IClientStore
-{
-    public Task<Client?> FindClientByIdAsync(string clientId, CancellationToken ct)
-    {
-        // ...
-    }
-
-    public IAsyncEnumerable<Client> GetAllClientsAsync(CancellationToken ct)
-    {
-        // ...
-    }
-}
++ // After (v8.0)
++ public class MyClientStore : IClientStore
++ {
++     public Task<Client?> FindClientByIdAsync(string clientId, CancellationToken ct)
++     {
++         // ...
++     }
++
++     public IAsyncEnumerable<Client> GetAllClientsAsync(CancellationToken ct)
++     {
++         // ...
++     }
++ }
 ```
 
 This applies to all store interfaces in `Duende.IdentityServer.Stores` and service interfaces in
@@ -241,7 +255,7 @@ dependency. Use the `CancellationToken` passed directly to interface methods ins
 IdentityServer now always uses HTTP 303 (See Other) for redirects from POST endpoints,
 in compliance with [FAPI 2.0 Section 5.3.2.2](https://openid.net/specs/fapi-security-profile-2_0.html).
 
-### IClientStore.GetAllClientsAsync Now Required
+### `IClientStore.GetAllClientsAsync` Now Required
 
 `IClientStore` now includes a second required method:
 
@@ -255,6 +269,119 @@ and configuration validation features. Return an async enumerable of all configu
 For the in-memory store, this returns all clients passed to `AddInMemoryClients`. For
 Entity Framework, it queries the `Clients` table. Custom implementations should return all clients
 without filtering.
+
+### `IRefreshTokenService` Method Signatures Changed
+
+The `CreateRefreshTokenAsync` and `UpdateRefreshTokenAsync` methods on `IRefreshTokenService` now accept dedicated request objects instead of individual parameters:
+
+```diff lang="csharp" title="IRefreshTokenService.cs"
+- // Before (v7.x)
+- public interface IRefreshTokenService
+- {
+-     Task<TokenValidationResult> ValidateRefreshTokenAsync(string token, Client client);
+-     Task<string> CreateRefreshTokenAsync(ClaimsPrincipal subject, Token accessToken, Client client);
+-     Task<string> UpdateRefreshTokenAsync(string handle, RefreshToken refreshToken, Client client);
+- }
+
++ // After (v8.0)
++ public interface IRefreshTokenService
++ {
++     Task<TokenValidationResult> ValidateRefreshTokenAsync(string token, Client client, CancellationToken ct);
++     Task<string> CreateRefreshTokenAsync(RefreshTokenCreationRequest request, CancellationToken ct);
++     Task<string> UpdateRefreshTokenAsync(RefreshTokenUpdateRequest request, CancellationToken ct);
++ }
+```
+
+The new `RefreshTokenCreationRequest` and `RefreshTokenUpdateRequest` types carry the same data as the old individual parameters. If you have a custom implementation or subclass of `DefaultRefreshTokenService`, update the method signatures and use the request objects to access the data previously passed as separate arguments.
+
+See the [Refresh Token Service reference](/identityserver/reference/services/refresh-token-service) for the updated interface documentation.
+
+### Nullable Reference Types Enabled Across All Assemblies
+
+Nullable reference types (NRT) are now enabled across all IdentityServer assemblies. Method return types and parameters now carry explicit nullability annotations:
+
+```diff lang="csharp"
+- // Before (v7.x) - return type was non-nullable (implicitly nullable)
+- Task<Client> FindClientByIdAsync(string clientId);
+
++ // After (v8.0) - explicitly nullable
++ Task<Client?> FindClientByIdAsync(string clientId, CancellationToken ct);
+```
+
+If you have custom implementations of IdentityServer interfaces, you may see new compiler warnings about null handling after upgrading. Update your code to handle nullable return values appropriately. The `#nullable enable` directive is now the default for all projects.
+
+### `response_mode` Validated Earlier in the Authorization Pipeline
+
+The `response_mode` parameter is now parsed and validated before grant-type and PKCE checks in the authorization endpoint pipeline. As a result, error responses generated during grant-type or PKCE validation will now be delivered using the client's requested `response_mode` (e.g., `fragment` or `form_post`) rather than the default mode.
+
+Most applications are unaffected by this change. It only impacts scenarios where code relied on the specific shape of error responses from the authorize endpoint when an invalid `response_mode` was combined with other validation failures.
+
+### DPoP Type Names Corrected
+
+Two DPoP type names contained a spelling error (`Validaton` instead of `Validation`). They have been renamed:
+
+| Before (v7.x)               | After (v8.0)                 |
+|-----------------------------|------------------------------|
+| `DPoPProofValidatonContext` | `DPoPProofValidationContext` |
+| `DPoPProofValidatonResult`  | `DPoPProofValidationResult`  |
+
+If your code references either of the old names, do a find-and-replace to update them.
+
+### PersistedGrantFilter Collection Properties Are Now Non-Nullable
+
+The `ClientIds` and `Types` properties on `PersistedGrantFilter` changed from nullable `IEnumerable<string>?` to non-nullable `IReadOnlyCollection<string>`, defaulting to empty collections:
+
+```diff lang="csharp" title="PersistedGrantFilter.cs"
+- // Before (v7.x)
+- public class PersistedGrantFilter
+- {
+-     public IEnumerable<string> ClientIds { get; set; }  // nullable, null by default
+-     public IEnumerable<string> Types { get; set; }      // nullable, null by default
+- }
+
++ // After (v8.0)
++ public class PersistedGrantFilter
++ {
++     public IReadOnlyCollection<string> ClientIds { get; set; } = [];  // non-nullable, empty by default
++     public IReadOnlyCollection<string> Types { get; set; } = [];      // non-nullable, empty by default
++ }
+```
+
+Replace null checks with count checks:
+
+```diff lang="csharp"
+- // Before (v7.x)
+- if (filter.ClientIds != null) { ... }
+
++ // After (v8.0)
++ if (filter.ClientIds.Count > 0) { ... }
+```
+
+### `IEnumerable<T>` Return Types Changed to `IReadOnlyCollection<T>`
+
+Several interface methods that previously returned `Task<IEnumerable<T>>` now return `Task<IReadOnlyCollection<T>>`. The change affects these interfaces:
+
+- `IResourceStore` — `FindIdentityResourcesByScopeNameAsync`, `FindApiScopesByNameAsync`, `FindApiResourcesByScopeNameAsync`, `FindApiResourcesByNameAsync`
+- `IPersistedGrantStore` — `GetAllAsync`
+- `IPersistedGrantService` — `GetAllGrantsAsync`
+- `IBackChannelAuthenticationRequestStore` — `GetLoginsForUserAsync`
+- `ISigningKeyStore` — `LoadKeysAsync`
+- `IIdentityProviderStore` — `GetAllSchemeNamesAsync`
+- `IIdentityServerInteractionService` — `GetAllUserGrantsAsync`
+- `IBackchannelAuthenticationInteractionService` — `GetPendingLoginRequestsForCurrentUserAsync`
+- `IUserSession` — `GetClientListAsync`, `GetSamlSessionListAsync`
+
+```diff lang="csharp"
+- // Before (v7.x)
+- Task<IEnumerable<IdentityResource>> FindIdentityResourcesByScopeNameAsync(
+-     IEnumerable<string> scopeNames, CancellationToken ct);
+
++ // After (v8.0)
++ Task<IReadOnlyCollection<IdentityResource>> FindIdentityResourcesByScopeNameAsync(
++     IEnumerable<string> scopeNames, CancellationToken ct);
+```
+
+`IReadOnlyCollection<T>` implements `IEnumerable<T>`, so callers that only enumerate the results are unaffected. Custom implementations of these interfaces must update their return types.
 
 ### DPoP Changes (JwtBearer Package)
 
@@ -272,6 +399,27 @@ was restructured for v8.0:
 
 Update any code that references `DPoPExtensions` to use `DPoPServiceCollectionExtensions` instead.
 
+### `IUserSession`: New SAML Session Methods (Breaking for Custom Implementations)
+
+Three new methods were added to `IUserSession` to support SAML 2.0 session tracking:
+
+```csharp
+Task AddSamlSessionAsync(SamlSpSessionData session, CancellationToken ct);
+Task<IReadOnlyCollection<SamlSpSessionData>> GetSamlSessionListAsync(CancellationToken ct);
+Task RemoveSamlSessionAsync(string entityId, CancellationToken ct);
+```
+
+If you have a custom `IUserSession` implementation, you must add these three methods. If you do not use SAML 2.0, the methods can have minimal implementations:
+
+```csharp
+public Task AddSamlSessionAsync(SamlSpSessionData session, CancellationToken ct) => Task.CompletedTask;
+public Task<IReadOnlyCollection<SamlSpSessionData>> GetSamlSessionListAsync(CancellationToken ct)
+    => Task.FromResult<IReadOnlyCollection<SamlSpSessionData>>([]);
+public Task RemoveSamlSessionAsync(string entityId, CancellationToken ct) => Task.CompletedTask;
+```
+
+See the [User Session Service reference](/identityserver/reference/services/user-session-service) for the full updated interface.
+
 ## Step 5: New Features
 
 ### SAML 2.0 Identity Provider
@@ -288,7 +436,7 @@ SAML 2.0 Identity Provider support requires an Enterprise Edition license.
 
 A new `Duende.IdentityServer.ConformanceReport` package generates an HTML report assessing your
 IdentityServer deployment against OAuth 2.1 and FAPI 2.0 specifications. See the
-[Conformance Report documentation](/identityserver/diagnostics/conformance-report.md) for details.
+[Conformance Report documentation](/identityserver/diagnostics/conformance-report/) for details.
 
 ## Step 6: Done!
 


### PR DESCRIPTION
Add v8 changes from products repo and include IdentityServer4 to v8 upgrade guide.

Need to determine whether to keep or remove IS4-to-v7, for now both can exist.