### PR TITLE
Modify license details and support heading

### DIFF
--- a/astro/src/content/docs/general/glossary.mdx
+++ b/astro/src/content/docs/general/glossary.mdx
@@ -266,7 +266,7 @@ mechanism allows for the detection of replay attacks with access and refresh tok
 
 ## SAML 2.0 Identity Provider
 
-**License: <Badge text="Standard (add-on)" />, <Badge text="Advanced" />, <Badge text="Custom" />**
+**License: <Badge text="Enterprise (legacy)" />, <Badge text="Standard (add-on)" />, <Badge text="Advanced" />, <Badge text="Custom" />**
 
 IdentityServer can act as a SAML 2.0 Identity Provider (IdP), issuing SAML assertions to Service Providers (SPs) that
 use the SAML 2.0 protocol rather than OAuth 2.0 / OpenID Connect. This is useful for integrating with enterprise SaaS
@@ -376,7 +376,7 @@ issues and bugs.
   _target="_blank"
 />
 
-## Priority Developer Support
+## Priority / Premium Developer Support
 
 **License: <Badge text="Enterprise (legacy)" />, <Badge text="Standard" />, <Badge text="Advanced" />, <Badge text="Custom" />**
 


### PR DESCRIPTION
Updated license information for SAML 2.0 Identity Provider and changed the heading for developer support.