### PR TITLE
docs: add SAML 2.0 IdP-Initiated sample reference

### DIFF
--- a/astro/src/content/docs/identityserver/saml/configuration.md
+++ b/astro/src/content/docs/identityserver/saml/configuration.md
@@ -432,4 +432,6 @@ new SamlServiceProvider
 IdP-initiated SSO requires the Service Provider to accept unsolicited SAML responses from the IdP. Only enable it for SPs that explicitly support and require this flow.
 :::
 
+For a working example, see the [SAML 2.0 IdP-Initiated sample](/identityserver/samples/saml.mdx).
+
 

--- a/astro/src/content/docs/identityserver/samples/saml.mdx
+++ b/astro/src/content/docs/identityserver/samples/saml.mdx
@@ -19,3 +19,14 @@ This sample demonstrates SP-initiated SAML 2.0 single sign-on using IdentityServ
   title="SAML 2.0 Basic Sample"
   target="_blank"
 />
+
+### SAML 2.0 IdP-Initiated SSO
+
+This sample demonstrates IdP-initiated SAML 2.0 single sign-on, where authentication begins at the Identity Provider rather than the Service Provider. It features a "My Apps" dashboard that allows authenticated users to launch into registered SAML applications directly. The same SP project is deployed as multiple application instances using environment variable configuration, orchestrated by .NET Aspire.
+
+<LinkCard
+  description="GitHub Repository for the SAML 2.0 IdP-Initiated Sample"
+  href="https://github.com/DuendeSoftware/samples/tree/main/IdentityServer/v8/SAML/IdPInitiated"
+  title="SAML 2.0 IdP-Initiated Sample"
+  target="_blank"
+/>


### PR DESCRIPTION
## Summary
- Adds IdP-Initiated SSO entry to the SAML samples page (`saml.mdx`) with LinkCard pointing to the new sample
- Adds cross-reference from the IdP-Initiated SSO section in `configuration.md` to the samples page

Follows the same pattern established in #1102 for the Basic sample.