### PR TITLE
Rename Client to Application and AuthorizationError to InteractionError

### DIFF
--- a/astro/src/content/docs/identityserver/upgrades/v7_4-to-v8_0.md
+++ b/astro/src/content/docs/identityserver/upgrades/v7_4-to-v8_0.md
@@ -590,6 +590,10 @@ public Task RemoveSamlSessionAsync(string entityId, CancellationToken ct) => Tas
 
 See the [User Session Service reference](/identityserver/reference/v8/services/user-session-service.md) for the full updated interface.
 
+### `ProfileDataRequestContext.Client` Renamed to `ProfileDataRequestContext.Application`
+
+The `ProfileDataRequestContext.Client` property has been renamed to `ProfileDataRequestContext.Application`.
+
 ### `AuthorizationError` Renamed to `InteractionError`
 
 The `AuthorizationError` enum has been renamed to `InteractionError`, and `DenyAuthorizationAsync`


### PR DESCRIPTION
Updated documentation to reflect renaming of properties and enums in IdentityServer.