### PR TITLE
Add license key update instructions for v8

### DIFF
--- a/astro/src/content/docs/identityserver/upgrades/v7_4-to-v8_0.md
+++ b/astro/src/content/docs/identityserver/upgrades/v7_4-to-v8_0.md
@@ -822,7 +822,11 @@ This aligns with [draft-ietf-oauth-rfc7523bis](https://datatracker.ietf.org/doc/
 
 **Impact:** Clients that send the `aud` claim as a single-element array (for example, `"aud": ["https://your-issuer"]`) will now pass strict audience validation where they previously would have failed. No action is required unless you relied on the stricter behavior.
 
-## Step 7: Done!
+## Step 7: Get an Updated License Key
+
+The license key format used in previous versions of IdentityServer is not compatible with IdentityServer v8. A new license key file will be required to run IdentityServer v8 in production. Please [contact our sales team](https://duendesoftware.com/contact/sales) to request an updated license file that corresponds to your existing license. Note that this is purely a technical change in the license format. No new subscription or purchase is necessary if you already have an active license.
+
+## Step 8: Done!
 
 That's it. Of course, at this point you can and should test that your IdentityServer is updated and
 working properly.

--- a/astro/src/content/docs/identityserver/upgrades/v7_4-to-v8_0.md
+++ b/astro/src/content/docs/identityserver/upgrades/v7_4-to-v8_0.md
@@ -824,8 +824,15 @@ This aligns with [draft-ietf-oauth-rfc7523bis](https://datatracker.ietf.org/doc/
 
 ## Step 7: Get an Updated License Key
 
-The license key format used in previous versions of IdentityServer is not compatible with IdentityServer v8. A new license key file will be required to run IdentityServer v8 in production. Please [contact our sales team](https://duendesoftware.com/contact/sales) to request an updated license file that corresponds to your existing license. Note that this is purely a technical change in the license format. No new subscription or purchase is necessary if you already have an active license.
+The license key format used in previous versions of IdentityServer is not compatible with IdentityServer v8.
+A new license key file will be required to run IdentityServer v8 in production.
+Please [contact our sales team](https://duendesoftware.com/contact/sales) to request an updated license file that corresponds
+to your existing license. Note that this is purely a technical change in the license format. No new subscription or purchase
+is necessary if you already have an active license.
 
+Once you receive the updated license file, replace the configured `LicenseKey` value (for example in `appsettings.json` or an
+environment variable) with the new key content. See the [licensing documentation](/general/licensing.md#license-key) for all
+supported configuration approaches.
 ## Step 8: Done!
 
 That's it. Of course, at this point you can and should test that your IdentityServer is updated and


### PR DESCRIPTION
Updated the upgrade documentation to include information about the new license key format required for IdentityServer v8.