### PR TITLE
Update Mermaid diagrams to use `material-symbols` icons, refine themes, and replace outdated SVG images for improved clarity and consistency.

### DIFF
--- a/astro/astro.config.mjs
+++ b/astro/astro.config.mjs
@@ -56,9 +56,18 @@ export default defineConfig({
   integrations: [
     mermaid({
       // Default theme: 'default', 'dark', 'forest', 'neutral', 'base'
-      theme: "forest",
+      theme: "default",
       autoTheme: true,
-      enableLog: false
+      enableLog: false,
+      iconPacks: [
+        {
+          name: "material-symbols",
+          loader: () =>
+            fetch("https://unpkg.com/@iconify-json/material-symbols@1/icons.json").then(
+              (res) => res.json()
+            ),
+        },
+      ],
     }),
     contributorMapping({
       include: ["src/content/docs/**"],

--- a/astro/package-lock.json
+++ b/astro/package-lock.json
@@ -15,7 +15,7 @@
         "@astrojs/ts-plugin": "^1.10.6",
         "@fontsource/funnel-sans": "^5.2.8",
         "@resvg/resvg-js": "^2.6.2",
-        "astro": "^6.1.0",
+        "astro": "6.1.10",
         "astro-mermaid": "^2.0.1",
         "astro-opengraph-images": "^1.14.3",
         "astro-redirect-from": "^1.3.5",
@@ -343,17 +343,16 @@
       }
     },
     "node_modules/@astrojs/telemetry": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
-      "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.1.tgz",
+      "integrity": "sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw==",
       "license": "MIT",
       "dependencies": {
-        "ci-info": "^4.2.0",
-        "debug": "^4.4.0",
+        "ci-info": "^4.4.0",
         "dlv": "^1.1.3",
         "dset": "^3.1.4",
-        "is-docker": "^3.0.0",
-        "is-wsl": "^3.1.0",
+        "is-docker": "^4.0.0",
+        "is-wsl": "^3.1.1",
         "which-pm-runs": "^1.1.0"
       },
       "engines": {
@@ -1416,9 +1415,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1434,9 +1430,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1454,9 +1447,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1472,9 +1462,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1492,9 +1479,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1510,9 +1494,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1530,9 +1511,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1549,9 +1527,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1567,9 +1542,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1593,9 +1565,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1617,9 +1586,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1643,9 +1609,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1667,9 +1630,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1693,9 +1653,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1718,9 +1675,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1742,9 +1696,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2166,9 +2117,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2184,9 +2132,6 @@
       "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -2204,9 +2149,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2222,9 +2164,6 @@
       "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -2396,9 +2335,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2411,9 +2347,6 @@
       "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2428,9 +2361,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2443,9 +2373,6 @@
       "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2460,9 +2387,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2475,9 +2399,6 @@
       "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2492,9 +2413,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2507,9 +2425,6 @@
       "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2524,9 +2439,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2539,9 +2451,6 @@
       "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2556,9 +2465,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2572,9 +2478,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2587,9 +2490,6 @@
       "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3510,15 +3410,15 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.4.tgz",
-      "integrity": "sha512-SRy1bONuCHkGWhI5JiWCQKVDVbeaXOikjAVZs/Nz+lvUvubtdLoZfnacmuZHQ9RL2IOkU54M8/qZYm9ypJDKrg==",
+      "version": "6.1.10",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.10.tgz",
+      "integrity": "sha512-jQAIki6c862oxRr7OXXC+h3n4wg1EpmKgCH3vv1FtXM9VFmD2iTjlaxrfb0I6eQCwtUjSBxfJBFBDSXHu7Wing==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^3.0.1",
-        "@astrojs/internal-helpers": "0.8.0",
-        "@astrojs/markdown-remark": "7.1.0",
-        "@astrojs/telemetry": "3.3.0",
+        "@astrojs/internal-helpers": "0.9.0",
+        "@astrojs/markdown-remark": "7.1.1",
+        "@astrojs/telemetry": "3.3.1",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
         "@oslojs/encoding": "^1.1.0",
@@ -3531,7 +3431,6 @@
         "cookie": "^1.1.1",
         "devalue": "^5.6.3",
         "diff": "^8.0.3",
-        "dlv": "^1.1.3",
         "dset": "^3.1.4",
         "es-module-lexer": "^2.0.0",
         "esbuild": "^0.27.3",
@@ -3550,7 +3449,7 @@
         "p-queue": "^9.1.0",
         "package-manager-detector": "^1.6.0",
         "piccolore": "^0.1.3",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "rehype": "^13.0.2",
         "semver": "^7.7.4",
         "shiki": "^4.0.2",
@@ -3563,9 +3462,9 @@
         "ultrahtml": "^1.6.0",
         "unifont": "~0.7.4",
         "unist-util-visit": "^5.1.0",
-        "unstorage": "^1.17.4",
+        "unstorage": "^1.17.5",
         "vfile": "^6.0.3",
-        "vite": "^7.3.1",
+        "vite": "^7.3.2",
         "vitefu": "^1.1.2",
         "xxhash-wasm": "^1.1.0",
         "yargs-parser": "^22.0.0",
@@ -3782,6 +3681,44 @@
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-3.0.1.tgz",
       "integrity": "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==",
       "license": "MIT"
+    },
+    "node_modules/astro/node_modules/@astrojs/internal-helpers": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.0.tgz",
+      "integrity": "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.4"
+      }
+    },
+    "node_modules/astro/node_modules/@astrojs/markdown-remark": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.1.tgz",
+      "integrity": "sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.9.0",
+        "@astrojs/prism": "4.0.1",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "js-yaml": "^4.1.1",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-smartypants": "^3.0.2",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.0",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
+        "unist-util-visit-parents": "^6.0.2",
+        "vfile": "^6.0.3"
+      }
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
@@ -6547,15 +6484,15 @@
       }
     },
     "node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
+      "integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6624,6 +6561,21 @@
       },
       "engines": {
         "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/astro/package.json
+++ b/astro/package.json
@@ -29,7 +29,7 @@
     "@astrojs/ts-plugin": "^1.10.6",
     "@fontsource/funnel-sans": "^5.2.8",
     "@resvg/resvg-js": "^2.6.2",
-    "astro": "^6.1.0",
+    "astro": "6.1.10",
     "astro-mermaid": "^2.0.1",
     "astro-opengraph-images": "^1.14.3",
     "astro-redirect-from": "^1.3.5",

--- a/astro/src/content/docs/identityserver/fundamentals/users.md
+++ b/astro/src/content/docs/identityserver/fundamentals/users.md
@@ -48,7 +48,38 @@ It is very important that you understand how it works when building the login pa
 Recall the diagram showing the relationship of your custom UI pages and the IdentityServer middleware in your
 IdentityServer host application:
 
-![middleware diagram](../overview/images/middleware.svg)
+```mermaid
+---
+title: ASP.NET Core Middleware Configuration
+---
+flowchart LR
+    login@{ icon: "material-symbols:login-rounded", label: "login", shape: icon }
+    logout@{ icon: "material-symbols:logout-rounded", label: "logout", shape: icon }
+    more@{ icon: "material-symbols:pending", label: "more...", shape: icon }
+    authorize@{ icon: "material-symbols:verified-user-rounded", label: "authorize", shape: icon }
+    token@{ icon: "material-symbols:key-rounded", label: "token", shape: icon }
+    discovery@{ icon: "material-symbols:travel-explore-rounded", label: "discovery", shape: icon }
+
+    subgraph ASPNET["ASP.NET Core Request Pipeline"]
+        direction TB
+        subgraph IS[" "]
+            is_space@{ icon: "material-symbols:security-rounded", label: "IdentityServer Middleware", shape: icon }
+        end
+        subgraph YC[" "]
+            yc_space@{ icon: "material-symbols:code-rounded", label: "Your Code", shape: icon }
+        end
+    end
+
+    login --> YC
+    logout --> YC
+    more --> YC
+    authorize --> IS
+    token --> IS
+    discovery --> IS
+
+    style YC stroke:#74acfb,stroke-width:2px
+    style IS stroke:#61fb92,stroke-width:2px
+```
 
 When your IdentityServer receives an authorize request, it will inspect it for a current authentication session for a
 user. This authentication session is based on ASP.NET Core's authentication system and is ultimately determined by a

--- a/astro/src/content/docs/identityserver/overview/big-picture.md
+++ b/astro/src/content/docs/identityserver/overview/big-picture.md
@@ -12,7 +12,28 @@ redirect_from:
 
 Most modern applications look more or less like this:
 
-![an architecture diagram for modern applications with clients and services](images/application-architecture.svg)
+```mermaid
+---
+title: Modern Application Architecture
+---
+flowchart LR
+    Browser@{ icon: "material-symbols:tabs-rounded", label: "Browser", shape: icon }
+    NativeApp@{ icon: "material-symbols:phone-android-rounded", label: "Native App", shape: icon }
+    ServerApp@{ icon: "material-symbols:computer-rounded", label: "Server / App", shape: icon }
+    Backend@{ icon: "material-symbols:storage-rounded", label: "Backend", shape: icon }
+    API_main@{ icon: "material-symbols:api-rounded", label: "API", shape: icon }
+    API_top@{ icon: "material-symbols:api-rounded", label: "API", shape: icon }
+    API_tail@{ icon: "material-symbols:api-rounded", label: "API", shape: icon }
+
+    Browser --> Backend
+    Browser --> API_main
+    Backend --> API_top
+    Backend --> API_main
+    NativeApp --> API_main
+    ServerApp --> API_main
+    API_main --> API_tail
+```
+
 
 The most common interactions are:
 
@@ -31,7 +52,27 @@ across those applications and endpoints.
 
 Restructuring the application to support a security token service leads to the following architecture and protocols:
 
-![an architecture diagram showing where OAuth 2.0 is used](images/protocols.svg)
+```mermaid
+---
+title: Protocols Used Within Architecture
+---
+flowchart LR
+    Browser@{ icon: "material-symbols:tabs-rounded", label: "Browser (OIDC)", shape: icon }
+    NativeApp@{ icon: "material-symbols:phone-android-rounded", label: "Native App (OIDC)", shape: icon }
+    ServerApp@{ icon: "material-symbols:computer-rounded", label: "Server / App", shape: icon }
+    Backend@{ icon: "material-symbols:storage-rounded", label: "Backend", shape: icon }
+    API_main@{ icon: "material-symbols:api-rounded", label: "API", shape: icon }
+    API_top@{ icon: "material-symbols:api-rounded", label: "API", shape: icon }
+    API_tail@{ icon: "material-symbols:api-rounded", label: "API", shape: icon }
+
+    Browser -- OIDC --> Backend
+    Browser -- OAUTH --> API_main
+    Backend -- OAUTH --> API_top
+    Backend -- OAUTH --> API_main
+    NativeApp -- OAUTH --> API_main
+    ServerApp -- OAUTH --> API_main
+    API_main -- OAUTH --> API_tail
+```
 
 Such a design divides security concerns into two parts:
 
@@ -78,7 +119,33 @@ depending on your needs)
 and add the IdentityServer middleware to that application. The middleware adds the necessary protocol heads to the
 application so that clients can talk to it using those standard protocols.
 
-![IdentityServer middleware diagram and its relationship in the ASP.NET Core pipeline](images/middleware.svg)
+```mermaid
+---
+title: ASP.NET Core Middleware Configuration
+---
+flowchart LR
+    login@{ icon: "material-symbols:login-rounded", label: "login", shape: icon }
+    logout@{ icon: "material-symbols:logout-rounded", label: "logout", shape: icon }
+    more@{ icon: "material-symbols:pending", label: "more...", shape: icon }
+    authorize@{ icon: "material-symbols:verified-user-rounded", label: "authorize", shape: icon }
+    token@{ icon: "material-symbols:key-rounded", label: "token", shape: icon }
+    discovery@{ icon: "material-symbols:travel-explore-rounded", label: "discovery", shape: icon }
+
+    subgraph ASPNET["ASP.NET Core Request Pipeline"]
+        direction TB
+        YC@{ icon: "material-symbols:code-rounded", label: "Your Code", shape: icon }
+        IS@{ icon: "material-symbols:security-rounded", label: "IdentityServer Middleware", shape: icon }
+    end
+
+    login --> ASPNET
+    logout --> ASPNET
+    more --> ASPNET
+    authorize --> ASPNET
+    token --> ASPNET
+    discovery --> ASPNET
+
+    style ASPNET stroke:#212121,stroke-width:1px
+```
 
 The hosting application can be as complex as you want, but we typically recommend to keep the attack surface as small as
 possible by including

--- a/astro/src/content/docs/identityserver/overview/big-picture.md
+++ b/astro/src/content/docs/identityserver/overview/big-picture.md
@@ -133,18 +133,23 @@ flowchart LR
 
     subgraph ASPNET["ASP.NET Core Request Pipeline"]
         direction TB
-        YC@{ icon: "material-symbols:code-rounded", label: "Your Code", shape: icon }
-        IS@{ icon: "material-symbols:security-rounded", label: "IdentityServer Middleware", shape: icon }
+        subgraph IS[" "]
+            is_space@{ icon: "material-symbols:security-rounded", label: "IdentityServer Middleware", shape: icon }
+        end
+        subgraph YC[" "]
+            yc_space@{ icon: "material-symbols:code-rounded", label: "Your Code", shape: icon }
+        end
     end
 
-    login --> ASPNET
-    logout --> ASPNET
-    more --> ASPNET
-    authorize --> ASPNET
-    token --> ASPNET
-    discovery --> ASPNET
+    login --> YC
+    logout --> YC
+    more --> YC
+    authorize --> IS
+    token --> IS
+    discovery --> IS
 
-    style ASPNET stroke:#212121,stroke-width:1px
+    style YC stroke:#74acfb,stroke-width:2px
+    style IS stroke:#61fb92,stroke-width:2px
 ```
 
 The hosting application can be as complex as you want, but we typically recommend to keep the attack surface as small as

--- a/astro/src/content/docs/identityserver/overview/terminology.md
+++ b/astro/src/content/docs/identityserver/overview/terminology.md
@@ -12,7 +12,20 @@ redirect_from:
 
 The specs, documentation and object model use a certain terminology that you should be aware of.
 
-![a basic diagrams showing the relationship between users, clients, identityserver, and resources](images/terminology.svg)
+```mermaid
+---
+title: Key Roles & Relationships
+---
+flowchart LR
+    Users@{ icon: "material-symbols:person-rounded", label: "Users", shape: icon }
+    IS@{ icon: "material-symbols:assured-workload-rounded", label: "Duende IdentityServer", shape: icon }
+    Clients@{ icon: "material-symbols:computer-rounded", label: "Clients", shape: icon }
+    Resources@{ icon: "material-symbols:api-rounded", label: "Resources", shape: icon }
+
+    Users --> Clients
+    Clients <-->|"authenticate users & request resource access"| IS
+    Clients --> Resources
+```
 
 ## Duende IdentityServer
 

--- a/astro/src/content/docs/identityserver/ui/index.md
+++ b/astro/src/content/docs/identityserver/ui/index.md
@@ -21,7 +21,38 @@ The design goal of Duende IdentityServer is to provide a full implementation of 
 
 To allow full flexibility of the UI, including business rules and user flow, the UI is separated from the core IdentityServer engine. The engine implements the endpoints specified in the protocols and hands off control to your code in the UI as necessary.
 
-![diagram showing how IdentityServer middleware is hosted in an ASP.NET Core application](images/host.svg)
+```mermaid
+---
+title: ASP.NET Core Middleware Configuration
+---
+flowchart LR
+    login@{ icon: "material-symbols:login-rounded", label: "login", shape: icon }
+    logout@{ icon: "material-symbols:logout-rounded", label: "logout", shape: icon }
+    more@{ icon: "material-symbols:pending", label: "more...", shape: icon }
+    authorize@{ icon: "material-symbols:verified-user-rounded", label: "authorize", shape: icon }
+    token@{ icon: "material-symbols:key-rounded", label: "token", shape: icon }
+    discovery@{ icon: "material-symbols:travel-explore-rounded", label: "discovery", shape: icon }
+
+    subgraph ASPNET["ASP.NET Core Request Pipeline"]
+        direction TB
+        subgraph IS[" "]
+            is_space@{ icon: "material-symbols:security-rounded", label: "IdentityServer Middleware", shape: icon }
+        end
+        subgraph YC[" "]
+            yc_space@{ icon: "material-symbols:code-rounded", label: "Your Code", shape: icon }
+        end
+    end
+
+    login --> YC
+    logout --> YC
+    more --> YC
+    authorize --> IS
+    token --> IS
+    discovery --> IS
+
+    style YC stroke:#74acfb,stroke-width:2px
+    style IS stroke:#61fb92,stroke-width:2px
+```
 
 Our templates include a [quick start UI](/identityserver/quickstarts/2-interactive.md#add-the-ui) and a [quick start UI adapted to ASP.NET Identity](/identityserver/quickstarts/5-aspnetid.md) which provide a starting point for all the necessary pages, ready to be customized.
 


### PR DESCRIPTION
Here's what these diagrams look like on the site.

<img width="3474" height="7204" alt="CleanShot 2026-06-09 at 10 39 18@2x" src="https://github.com/user-attachments/assets/4a6e3790-e4c3-4b0b-9aa2-a9d91b03ed1f" />

also, scrolling screenshot broke the last one.

<img width="1510" height="1410" alt="CleanShot 2026-06-09 at 10 40 00@2x" src="https://github.com/user-attachments/assets/7b016507-f3a5-473a-986d-159fc963c683" />

