### PR TITLE
Corrected and added licensing details on featuresets

### DIFF
--- a/astro/src/content/docs/identityserver/tokens/jar.md
+++ b/astro/src/content/docs/identityserver/tokens/jar.md
@@ -11,8 +11,12 @@ redirect_from:
   - /identityserver/v7/tokens/jar/
 ---
 
+:::note
+This feature is part of the [Duende IdentityServer Enterprise (legacy), Standard, Advanced, and Custom Edition](https://duendesoftware.com/products/identityserver).
+:::
+
 Instead of providing the parameters for an authorize request as individual query string key/value pairs, you can package them up in signed JWTs.
-This makes the parameters tamperproof and you can authenticate the client already on the front-channel.
+This makes the parameters tamperproof, and you can authenticate the client already on the front-channel.
 
 :::note
 See [here](/identityserver/samples/basics.mdx#mvc-client-with-jar-and-jwt-based-authentication) for a sample for using signed authorize requests (and JWT-based authentication) in ASP.NET Core.

--- a/astro/src/content/docs/identityserver/tokens/par.md
+++ b/astro/src/content/docs/identityserver/tokens/par.md
@@ -35,11 +35,12 @@ care, and in other industries with high security requirements.
 ## Licensing
 
 :::note
-This feature is part of the [Duende IdentityServer Business (legacy), Enterprise (legacy), Standard, Advanced, and Custom Edition](https://duendesoftware.com/products/identityserver).
+This feature is part of the [Duende IdentityServer Business (legacy), Enterprise (legacy), Lite, Standard, Advanced, and Custom Edition](https://duendesoftware.com/products/identityserver).
 :::
 
-In the Starter edition, PAR requests will not be processed and instead log errors. If you have a starter edition license, you should disable the
-`EnablePushedAuthorizationEndpoint` flag so that discovery indicates that your IdentityServer does not support PAR:
+In the Duende IdentityServer Starter (legacy) edition, PAR requests will not be processed and instead log errors. 
+If you have a starter edition license, you should disable the `EnablePushedAuthorizationEndpoint` flag so that discovery 
+indicates that your IdentityServer does not support PAR:
 
 ```csharp
 // Program.cs

--- a/astro/src/content/docs/identityserver/tokens/pop.md
+++ b/astro/src/content/docs/identityserver/tokens/pop.md
@@ -62,6 +62,10 @@ The client must then use the same client certificate to call the APIs, and your 
 
 If the access token would leak, it cannot be replayed without having access to the additional private key of the X.509 client certificate.
 
+:::note
+This feature is part of the [Duende IdentityServer Enterprise (legacy), Standard, Advanced, and Custom Edition](https://duendesoftware.com/products/identityserver).
+:::
+
 ### Combine TLS Proof-of-possession With Other Authentication Methods
 
 It is not mandatory to authenticate your clients with a client certificate to get the benefit of proof-of-possession. You can combine this feature with an arbitrary client authentication method - or even no client authentication at all (e.g. for public mobile/native clients).
@@ -157,7 +161,7 @@ var idsvrBuilder = builder.Services.AddIdentityServer(options =>
 attacks by making it difficult for attackers to use stolen tokens.
 
 :::note
-This feature is part of the [Duende IdentityServer Enterprise (legacy), Standard, Advanced, and Custom Edition](https://duendesoftware.com/products/identityserver).
+This feature is part of the [Duende IdentityServer Enterprise (legacy), Lite, Standard, Advanced, and Custom Edition](https://duendesoftware.com/products/identityserver).
 :::
 
 DPoP specifies how to bind


### PR DESCRIPTION
This pull request updates the documentation for several Duende IdentityServer features to clarify licensing requirements and edition support. The changes ensure that users are informed about which product editions are required for specific advanced features, and they provide updated guidance and notes in relevant documentation files.

Licensing and edition clarifications:

* Added a licensing note to the `jar.md` documentation, specifying that the JWT Authorization Request (JAR) feature is available in the Enterprise (legacy), Standard, Advanced, and Custom Editions.
* Updated the licensing note in the `par.md` documentation to include the Lite edition as supporting Pushed Authorization Requests (PAR), and clarified that the Starter (legacy) edition does not process PAR requests.
* Added a licensing note to the `pop.md` documentation, indicating that the mTLS feature is available in the Enterprise (legacy), Standard, Advanced, and Custom Editions.
* Updated the licensing note in the `pop.md` documentation to also include the Lite edition as supporting DPoP.