### PR TITLE
Some rewording + added Content-Type to fix the HTTP request

### DIFF
--- a/astro/src/content/docs/identityserver/reference/v7/endpoints/introspection.md
+++ b/astro/src/content/docs/identityserver/reference/v7/endpoints/introspection.md
@@ -14,7 +14,8 @@ The introspection endpoint is an implementation of [RFC 7662](https://tools.ietf
 It can be used to validate reference tokens, JWTs (if the consumer does not have support for appropriate JWT or
 cryptographic libraries) and refresh tokens. Refresh tokens can only be introspected by the client that requested them.
 
-The introspection endpoint requires authentication. Since the request to the introspection endpoint is typically done by an API, which is not an OAuth client, the [`ApiResource`](/identityserver/fundamentals/resources/api-resources.md) is used to configure credentials:
+The introspection endpoint requires authentication. Since the request to the introspection endpoint is typically done by 
+an API, which is not an OAuth client, the [`ApiResource`](/identityserver/fundamentals/resources/api-resources.md) is used to configure credentials:
 
 ```csharp
 new ApiResource("resource1")
@@ -27,10 +28,12 @@ new ApiResource("resource1")
     }
 }
 ```
-Here the id used for authentication is the name of the `ApiResource`: "resource1" and the secret the configured secret. The introspection endpoint uses HTTP basic auth to communicate these credentials:
+The ID used for authentication is the name of the `ApiResource`, "resource1", and the secret is the configured secret. 
+The introspection endpoint uses HTTP basic auth to communicate these credentials:
 
 ```text
 POST /connect/introspect
+Content-Type: application/x-www-form-urlencoded
 Authorization: Basic xxxyyy
 
 token=<token>
@@ -71,6 +74,7 @@ To return a JWT response, set the `Accept` header in the HTTP request to `applic
 
 ```text
 POST /connect/introspect
+Content-Type: application/x-www-form-urlencoded
 Accept: application/token-introspection+jwt
 Authorization: Basic xxxyyy
 

--- a/astro/src/content/docs/identityserver/reference/v8/endpoints/introspection.md
+++ b/astro/src/content/docs/identityserver/reference/v8/endpoints/introspection.md
@@ -16,7 +16,8 @@ The introspection endpoint is an implementation of [RFC 7662](https://tools.ietf
 It can be used to validate reference tokens, JWTs (if the consumer does not have support for appropriate JWT or
 cryptographic libraries) and refresh tokens. Refresh tokens can only be introspected by the client that requested them.
 
-The introspection endpoint requires authentication. Since the request to the introspection endpoint is typically done by an API, which is not an OAuth client, the [`ApiResource`](/identityserver/fundamentals/resources/api-resources.md) is used to configure credentials:
+The introspection endpoint requires authentication. Since the request to the introspection endpoint is typically done by 
+an API, which is not an OAuth client, the [`ApiResource`](/identityserver/fundamentals/resources/api-resources.md) is used to configure credentials:
 
 ```csharp
 new ApiResource("resource1")
@@ -29,10 +30,12 @@ new ApiResource("resource1")
     }
 }
 ```
-Here the id used for authentication is the name of the `ApiResource`: "resource1" and the secret the configured secret. The introspection endpoint uses HTTP basic auth to communicate these credentials:
+The ID used for authentication is the name of the `ApiResource`, "resource1", and the secret is the configured secret.
+The introspection endpoint uses HTTP basic auth to communicate these credentials:
 
 ```text
 POST /connect/introspect
+Content-Type: application/x-www-form-urlencoded
 Authorization: Basic xxxyyy
 
 token=<token>
@@ -73,6 +76,7 @@ To return a JWT response, set the `Accept` header in the HTTP request to `applic
 
 ```text
 POST /connect/introspect
+Content-Type: application/x-www-form-urlencoded
 Accept: application/token-introspection+jwt
 Authorization: Basic xxxyyy
 


### PR DESCRIPTION
Added the correct `Content-Type` in the HTTP requests to the introspection endpoint. If someone were to try this HTTP request, they'd encounter a `415 Unsupported Media Type` error if no content type (or the wrong one) was specified.