### PR TITLE
Add API documentation for core services in v8

### DIFF
--- a/astro/src/content/docs/identityserver/reference/v7/models/secrets.md
+++ b/astro/src/content/docs/identityserver/reference/v7/models/secrets.md
@@ -87,7 +87,7 @@ The parsed secret is forwarded to the registered secret validator. The validator
 property to determine if this secret is something that can be validated by that validator instance. If yes, it will know
 how to cast the `Credential` object into a format that is understood.
 
-#### Duende.IdentityServer.Validation.ISecretParser
+#### Duende.IdentityServer.Validation.ISecretValidator
 
 Validates a parsed secret.
 

--- a/astro/src/content/docs/identityserver/reference/v7/services/device-flow-interaction-service.md
+++ b/astro/src/content/docs/identityserver/reference/v7/services/device-flow-interaction-service.md
@@ -18,23 +18,23 @@ MVC controllers for the user interface of IdentityServer.
 
 ## IDeviceFlowInteractionService APIs
 
-* **`GetAuthorizationContextAsync`**
+* **`GetAuthorizationContextAsync(string userCode)`**
 
   Returns the `DeviceFlowAuthorizationRequest` based on the `userCode` passed to the login or consent pages.
 
-* **`DeviceFlowInteractionResult`**
+* **`HandleRequestAsync(string userCode, ConsentResponse consent)`**
 
   Completes device authorization for the given `userCode`.
 
 ## DeviceFlowAuthorizationRequest
 
-* **`ClientId`**
+* **`Client`**
 
-  The client identifier that initiated the request.
+  The client that initiated the device authorization request.
 
-* **`ScopesRequested`**
+* **`ValidatedResources`**
 
-  The scopes requested from the authorization request.
+  The validated resources (scopes and resource indicators) requested by the client.
 
 ## DeviceFlowInteractionResult
 
@@ -42,6 +42,14 @@ MVC controllers for the user interface of IdentityServer.
 
   Specifies if the authorization request errored.
 
+* **`IsAccessDenied`**
+
+  Gets or sets a value indicating whether the user denied access.
+
 * **`ErrorDescription`**
 
   Error description upon failure.
+
+* **`Failure(string errorDescription = null)`** *(static method)*
+
+  Creates a `DeviceFlowInteractionResult` indicating failure with an optional error description.

--- a/astro/src/content/docs/identityserver/reference/v7/validators/redirect-uri-validator.md
+++ b/astro/src/content/docs/identityserver/reference/v7/validators/redirect-uri-validator.md
@@ -6,6 +6,7 @@ sidebar:
   order: 30
 redirect_from:
   - /identityserver/v7/reference/validators/redirect_uri_validator/
+  - /identityserver/reference/v7/validators/redirect_uri_validator/ 
 ---
 
 #### Duende.IdentityServer.Validation.IRedirectUriValidator

--- a/astro/src/content/docs/identityserver/reference/v8/efoptions/configuration.md
+++ b/astro/src/content/docs/identityserver/reference/v8/efoptions/configuration.md
@@ -85,3 +85,14 @@ Identity provider related tables:
 
 * **`IdentityProvider`**
 
+SAML Service Provider related tables:
+
+* **`SamlServiceProvider`**
+* **`SamlAssertionConsumerService`**
+* **`SamlSingleLogoutService`**
+* **`SamlCertificate`**
+* **`SamlClaimMapping`**
+* **`SamlAuthnContextMapping`**
+* **`SamlAllowedScope`**
+* **`SamlRequestedClaimType`**
+

--- a/astro/src/content/docs/identityserver/reference/v8/efoptions/operational.md
+++ b/astro/src/content/docs/identityserver/reference/v8/efoptions/operational.md
@@ -52,10 +52,14 @@ Settings that affect the database schema and table names.
 * **`DeviceFlowCodes`**
 * **`Keys`**
 * **`ServerSideSessions`**
+* **`PushedAuthorizationRequests`**
+* **`SamlSigninStates`**
+* **`SamlLogoutSessions`**
+* **`SamlLogoutSessionRequestIndices`**
 
 ### Persisted Grants Cleanup
 
-Settings that affect the background cleanup of expired entries (tokens) from the persisted grants table.
+Settings that affect the background cleanup of expired entries from the operational store. Cleanup includes persisted grants, device codes, pushed authorization requests, SAML signin states, and SAML logout sessions.
 
 * **`EnableTokenCleanup`**
 
@@ -68,6 +72,10 @@ Settings that affect the background cleanup of expired entries (tokens) from the
 
   Gets or sets a value indicating whether consumed tokens will be included in the automatic clean up.
   Defaults to `false`.
+
+* **`ConsumedTokenCleanupDelay`**
+
+  Gets or sets the consumed token cleanup delay (in seconds). The default is `0`. This delay is the amount of time that must elapse before tokens marked as consumed can be deleted. Note that only refresh tokens with OneTimeOnly usage can be marked as consumed.
 
 * **`TokenCleanupInterval`**
 

--- a/astro/src/content/docs/identityserver/reference/v8/models/ciba-login-request.md
+++ b/astro/src/content/docs/identityserver/reference/v8/models/ciba-login-request.md
@@ -15,7 +15,7 @@ Models the information to initiate a user login request for [CIBA](/identityserv
 
 * **`InternalId`**
 
-  Ihe identifier of the request in the store.
+  The identifier of the request in the store.
 
 * **`Subject`**
 
@@ -48,3 +48,7 @@ Models the information to initiate a user login request for [CIBA](/identityserv
 * **`ValidatedResources`**
 
   The validated resources (i.e. scopes) used in the request.
+
+* **`Properties`**
+
+  A dictionary of custom properties associated with this request. These properties are by default copied from the validated custom request parameters.

--- a/astro/src/content/docs/identityserver/reference/v8/models/secrets.md
+++ b/astro/src/content/docs/identityserver/reference/v8/models/secrets.md
@@ -21,8 +21,9 @@ public interface ISecretParser
     /// Tries to find a secret on the context that can be used for authentication
     /// </summary>
     /// <param name="context">The HTTP context.</param>
+    /// <param name="ct">The cancellation token.</param>
     /// <returns>A parsed secret</returns>
-    Task<ParsedSecret> ParseAsync(HttpContext context);
+    Task<ParsedSecret> ParseAsync(HttpContext context, CancellationToken ct);
 
     /// <summary>
     /// Returns the authentication method name that this parser implements
@@ -89,7 +90,7 @@ The parsed secret is forwarded to the registered secret validator. The validator
 property to determine if this secret is something that can be validated by that validator instance. If yes, it will know
 how to cast the `Credential` object into a format that is understood.
 
-#### Duende.IdentityServer.Validation.ISecretParser
+#### Duende.IdentityServer.Validation.ISecretValidator
 
 Validates a parsed secret.
 
@@ -99,9 +100,11 @@ public interface ISecretValidator
     /// <summary>Validates a secret</summary>
     /// <param name="secrets">The stored secrets.</param>
     /// <param name="parsedSecret">The received secret.</param>
+    /// <param name="ct">The cancellation token.</param>
     /// <returns>A validation result</returns>
     Task<SecretValidationResult> ValidateAsync(
       IEnumerable<Secret> secrets,
-      ParsedSecret parsedSecret);
+      ParsedSecret parsedSecret,
+      CancellationToken ct);
 }
 ```

--- a/astro/src/content/docs/identityserver/reference/v8/response-handling/index.md
+++ b/astro/src/content/docs/identityserver/reference/v8/response-handling/index.md
@@ -13,3 +13,53 @@ redirect_from:
 IdentityServer's endpoints follow a pattern of abstraction in which a response generator uses a validated input model to produce a response model. The response model is a type that represents the data that will be returned from the endpoint. The response model is then wrapped in a result model, which is a type that facilitates serialization by an implementation of `IHttpResponseWriter`.
 
 Customization of protocol endpoint responses is possible in both the response generators and response writers. Response generator customization is appropriate when you want to change the "business logic" of an endpoint and is typically accomplished by overriding virtual methods in the default response generator. Response writer customization is appropriate when you want to change the serialization, encoding, or headers of the HTTP response and is accomplished by registering a custom implementation of the `IHttpResponseWriter`.
+
+## Available Response Generators
+
+| Interface | Default Implementation | Endpoint |
+|-----------|----------------------|----------|
+| `IAuthorizeInteractionResponseGenerator` | `AuthorizeInteractionResponseGenerator` | Authorize |
+| `IAuthorizeResponseGenerator` | `AuthorizeResponseGenerator` | Authorize |
+| `ITokenResponseGenerator` | `TokenResponseGenerator` | Token |
+| `IDiscoveryResponseGenerator` | `DiscoveryResponseGenerator` | Discovery |
+| `IIntrospectionResponseGenerator` | `IntrospectionResponseGenerator` | Introspection |
+| `ITokenRevocationResponseGenerator` | `TokenRevocationResponseGenerator` | Revocation |
+| `IUserInfoResponseGenerator` | `UserInfoResponseGenerator` | UserInfo |
+| `IDeviceAuthorizationResponseGenerator` | `DeviceAuthorizationResponseGenerator` | Device Authorization |
+| `IBackchannelAuthenticationResponseGenerator` | `BackchannelAuthenticationResponseGenerator` | CIBA |
+| `IPushedAuthorizationResponseGenerator` | `PushedAuthorizationResponseGenerator` | Pushed Authorization |
+
+## Customization Pattern
+
+To customize a response generator, inherit from the default implementation and override its virtual methods:
+
+```csharp
+public class CustomTokenResponseGenerator : TokenResponseGenerator
+{
+    public CustomTokenResponseGenerator(
+        ITokenService tokenService,
+        IRefreshTokenService refreshTokenService,
+        IScopeParser scopeParser,
+        IResourceStore resources,
+        IClientStore clients,
+        ILogger<TokenResponseGenerator> logger)
+        : base(tokenService, refreshTokenService, scopeParser, resources, clients, logger)
+    {
+    }
+
+    protected override async Task<TokenResponse> ProcessAuthorizationCodeRequestAsync(
+        TokenRequestValidationResult request, CancellationToken ct)
+    {
+        var response = await base.ProcessAuthorizationCodeRequestAsync(request, ct);
+        // Add custom response parameters
+        response.Custom["custom_field"] = "custom_value";
+        return response;
+    }
+}
+```
+
+Register your custom implementation:
+
+```csharp
+builder.Services.AddTransient<ITokenResponseGenerator, CustomTokenResponseGenerator>();
+```

--- a/astro/src/content/docs/identityserver/reference/v8/services/ciba-user-notification.md
+++ b/astro/src/content/docs/identityserver/reference/v8/services/ciba-user-notification.md
@@ -16,9 +16,74 @@ The `IBackchannelAuthenticationUserNotificationService` interface is used to con
 a [CIBA](/identityserver/ui/ciba.md) login request has been made.
 To use CIBA, you are expected to implement this interface and register it in the ASP.NET Core service provider.
 
+```csharp
+/// <summary>
+/// Used to contact users when a Client-Initiated Backchannel Authentication (CIBA)
+/// login request has been made. To use CIBA, you must implement this interface and
+/// register it in the ASP.NET Core service provider. The implementation is responsible
+/// for delivering the login notification to the user via an out-of-band channel such
+/// as push notification, SMS, or email.
+/// </summary>
+public interface IBackchannelAuthenticationUserNotificationService
+{
+    /// <summary>
+    /// Sends a notification for the user to login.
+    /// </summary>
+    /// <param name="request">The login request details.</param>
+    /// <param name="ct">The cancellation token.</param>
+    Task SendLoginRequestAsync(BackchannelUserLoginRequest request, CancellationToken ct);
+}
+```
+
 ## IBackchannelAuthenticationUserNotificationService APIs
 
 * **`SendLoginRequestAsync(BackchannelUserLoginRequest request, CancellationToken ct)`**
 
   Sends a notification for the user to login via
   the [BackchannelUserLoginRequest](/identityserver/reference/v8/models/ciba-login-request.md) parameter.
+
+## Sample Implementation
+
+The following example shows a minimal implementation that sends a push notification to the user. Your implementation should use whatever out-of-band communication channel is appropriate for your users (push notification, SMS, email, etc.).
+
+```csharp
+public class CibaUserNotificationService : IBackchannelAuthenticationUserNotificationService
+{
+    private readonly IPushNotificationService _pushService;
+    private readonly ILogger<CibaUserNotificationService> _logger;
+
+    public CibaUserNotificationService(
+        IPushNotificationService pushService,
+        ILogger<CibaUserNotificationService> logger)
+    {
+        _pushService = pushService;
+        _logger = logger;
+    }
+
+    public async Task SendLoginRequestAsync(
+        BackchannelUserLoginRequest request, CancellationToken ct)
+    {
+        var sub = request.Subject.FindFirst("sub")?.Value;
+
+        _logger.LogInformation(
+            "Sending CIBA login notification to user {Sub} for client {ClientId}",
+            sub, request.Client.ClientId);
+
+        await _pushService.SendAsync(
+            userId: sub,
+            title: "Login Request",
+            body: request.BindingMessage ?? "A login request has been made on your behalf.",
+            data: new Dictionary<string, string>
+            {
+                ["loginRequestId"] = request.InternalId
+            },
+            cancellationToken: ct);
+    }
+}
+```
+
+Register the implementation in your service collection:
+
+```csharp
+builder.Services.AddTransient<IBackchannelAuthenticationUserNotificationService, CibaUserNotificationService>();
+```

--- a/astro/src/content/docs/identityserver/reference/v8/services/claims-service.md
+++ b/astro/src/content/docs/identityserver/reference/v8/services/claims-service.md
@@ -1,0 +1,121 @@
+---
+title: "Claims Service"
+description: Documentation for the IClaimsService interface which is responsible for determining which claims to include in identity tokens and access tokens.
+sidebar:
+  label: Claims
+  order: 45
+---
+
+#### Duende.IdentityServer.Services.IClaimsService
+
+The `IClaimsService` is responsible for determining which claims to include in tokens. It is called by the `ITokenService` during token creation and works in conjunction with the `IProfileService` to assemble the final set of claims for both identity tokens and access tokens.
+
+```csharp
+/// <summary>
+/// The claims service is responsible for determining which claims to include in tokens.
+/// </summary>
+public interface IClaimsService
+{
+    /// <summary>
+    /// Returns claims for an identity token.
+    /// </summary>
+    /// <param name="subject">The subject.</param>
+    /// <param name="resources">The requested resources.</param>
+    /// <param name="includeAllIdentityClaims">Whether to include all identity claims.</param>
+    /// <param name="request">The validated request.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>Claims for the identity token.</returns>
+    Task<IReadOnlyCollection<Claim>> GetIdentityTokenClaimsAsync(
+        ClaimsPrincipal subject,
+        ResourceValidationResult resources,
+        bool includeAllIdentityClaims,
+        ValidatedRequest request,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Returns claims for an access token.
+    /// </summary>
+    /// <param name="subject">The subject.</param>
+    /// <param name="resources">The requested resources.</param>
+    /// <param name="request">The validated request.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>Claims for the access token.</returns>
+    Task<IReadOnlyCollection<Claim>> GetAccessTokenClaimsAsync(
+        ClaimsPrincipal subject,
+        ResourceValidationResult resources,
+        ValidatedRequest request,
+        CancellationToken ct);
+}
+```
+
+## IClaimsService APIs
+
+* **`GetIdentityTokenClaimsAsync(ClaimsPrincipal subject, ResourceValidationResult resources, bool includeAllIdentityClaims, ValidatedRequest request, CancellationToken ct)`**
+
+  Returns the claims to include in an identity token. The `includeAllIdentityClaims` parameter indicates whether all identity claims should be included (e.g., when `AlwaysIncludeUserClaimsInIdToken` is set on the client, or when there is no access token being issued).
+
+* **`GetAccessTokenClaimsAsync(ClaimsPrincipal subject, ResourceValidationResult resources, ValidatedRequest request, CancellationToken ct)`**
+
+  Returns the claims to include in an access token.
+
+## Default Implementation
+
+The `DefaultClaimsService` is the built-in implementation. It calls `IProfileService.GetProfileDataAsync` to retrieve claims based on the requested claim types from the relevant identity resources and API scopes.
+
+## Relationship to Other Services
+
+The `IClaimsService` sits within a hierarchy of token-related services:
+
+- **`IProfileService`**: Provides user-centric profile data (claims source)
+- **`IClaimsService`**: Determines which claims to include in each token type
+- **`ITokenService`**: Builds the complete `Token` model including claims, lifetime, and signing info
+- **`ITokenCreationService`**: Serializes the `Token` model into a JWT
+
+For most scenarios, customizing claims is best done through `IProfileService`. Use `IClaimsService` when you need to customize the claim-selection logic itself (e.g., filtering, transforming, or augmenting claims differently for identity tokens vs access tokens).
+
+## Sample Implementation
+
+The following example shows a custom claims service that adds a custom claim to all access tokens:
+
+```csharp
+public class CustomClaimsService : DefaultClaimsService
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CustomClaimsService(
+        IProfileService profile,
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<DefaultClaimsService> logger)
+        : base(profile, logger)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public override async Task<IReadOnlyCollection<Claim>> GetAccessTokenClaimsAsync(
+        ClaimsPrincipal subject,
+        ResourceValidationResult resources,
+        ValidatedRequest request,
+        CancellationToken ct)
+    {
+        var claims = await base.GetAccessTokenClaimsAsync(subject, resources, request, ct);
+
+        var mutableClaims = claims.ToList();
+        mutableClaims.Add(new Claim("tenant_id", ResolveTenantId()));
+
+        return mutableClaims;
+    }
+
+    private string ResolveTenantId()
+    {
+        // Resolve tenant from the current request context
+        var host = _httpContextAccessor.HttpContext?.Request.Host.Value;
+        return host?.Split('.').FirstOrDefault() ?? "default";
+    }
+}
+```
+
+Register the implementation:
+
+```csharp
+builder.Services.AddTransient<IClaimsService, CustomClaimsService>();
+```

--- a/astro/src/content/docs/identityserver/reference/v8/services/device-flow-interaction-service.md
+++ b/astro/src/content/docs/identityserver/reference/v8/services/device-flow-interaction-service.md
@@ -32,13 +32,13 @@ All async methods accept a `CancellationToken ct` parameter.
 
 ## DeviceFlowAuthorizationRequest
 
-* **`ClientId`**
+* **`Client`**
 
-  The client identifier that initiated the request.
+  The client that initiated the device authorization request.
 
-* **`ScopesRequested`**
+* **`ValidatedResources`**
 
-  The scopes requested from the authorization request.
+  The validated resources (scopes and resource indicators) requested by the client.
 
 ## DeviceFlowInteractionResult
 
@@ -46,6 +46,14 @@ All async methods accept a `CancellationToken ct` parameter.
 
   Specifies if the authorization request errored.
 
+* **`IsAccessDenied`**
+
+  Gets or sets a value indicating whether the user denied access.
+
 * **`ErrorDescription`**
 
   Error description upon failure.
+
+* **`Failure(string errorDescription = null)`** *(static method)*
+
+  Creates a `DeviceFlowInteractionResult` indicating failure with an optional error description.

--- a/astro/src/content/docs/identityserver/reference/v8/services/event-sink.md
+++ b/astro/src/content/docs/identityserver/reference/v8/services/event-sink.md
@@ -1,0 +1,119 @@
+---
+title: "Event Sink"
+description: Documentation for the IEventSink interface which handles the persistence or forwarding of IdentityServer events to external systems such as logging frameworks, audit databases, or SIEM solutions.
+sidebar:
+  label: Event Sink
+  order: 70
+---
+
+#### Duende.IdentityServer.Services.IEventSink
+
+The `IEventSink` interface handles the persistence or forwarding of IdentityServer events raised by `IEventService`. Implement this interface to integrate IdentityServer's event stream with an external system such as a logging framework, audit database, or SIEM solution.
+
+```csharp
+/// <summary>
+/// Handles the persistence or forwarding of IdentityServer events raised by IEventService.
+/// Implement this interface to integrate IdentityServer's event stream with an external system
+/// such as a logging framework, audit database, or SIEM solution.
+/// </summary>
+public interface IEventSink
+{
+    /// <summary>
+    /// Persists the event to the sink.
+    /// </summary>
+    /// <param name="evt">The event.</param>
+    /// <param name="ct">The cancellation token.</param>
+    Task PersistAsync(Event evt, CancellationToken ct);
+}
+```
+
+## IEventSink APIs
+
+* **`PersistAsync(Event evt, CancellationToken ct)`**
+
+  Called whenever an event is raised by IdentityServer. The `evt` parameter contains the event data including the event type, category, name, timestamp, and event-specific properties.
+
+## Event Types
+
+IdentityServer raises events for various activities, all inheriting from the base `Event` class in the `Duende.IdentityServer.Events` namespace. Common event categories include:
+
+- **Authentication** — User login success/failure, logout
+- **Token** — Token issued, token issued failure
+- **Grants** — Consent granted/denied, grants revoked
+- **Device Flow** — Device authorization success/failure
+- **CIBA** — Backchannel authentication events
+
+## Enabling Events
+
+Events must be enabled in the IdentityServer options. By default, error and failure events are enabled. To receive all events:
+
+```csharp
+builder.Services.AddIdentityServer(options =>
+{
+    options.Events.RaiseSuccessEvents = true;
+    options.Events.RaiseFailureEvents = true;
+    options.Events.RaiseErrorEvents = true;
+    options.Events.RaiseInformationEvents = true;
+});
+```
+
+## Default Implementation
+
+The `DefaultEventSink` writes events to the configured `ILogger` infrastructure. Events are serialized to JSON and written at the appropriate log level.
+
+## Multiple Event Sinks
+
+You can register multiple `IEventSink` implementations. All registered sinks will receive every raised event:
+
+```csharp
+builder.Services.AddTransient<IEventSink, AuditDatabaseEventSink>();
+builder.Services.AddTransient<IEventSink, SiemEventSink>();
+```
+
+## Sample Implementation
+
+The following example shows an event sink that writes audit events to a database:
+
+```csharp
+public class AuditDatabaseEventSink : IEventSink
+{
+    private readonly AuditDbContext _dbContext;
+    private readonly ILogger<AuditDatabaseEventSink> _logger;
+
+    public AuditDatabaseEventSink(
+        AuditDbContext dbContext,
+        ILogger<AuditDatabaseEventSink> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task PersistAsync(Event evt, CancellationToken ct)
+    {
+        var auditEntry = new AuditEntry
+        {
+            EventType = evt.EventType.ToString(),
+            Category = evt.Category,
+            Name = evt.Name,
+            Timestamp = evt.TimeStamp,
+            ActivityId = evt.ActivityId,
+            RemoteIpAddress = evt.RemoteIpAddress,
+            // Serialize the full event for detailed audit trail
+            EventData = JsonSerializer.Serialize(evt, evt.GetType())
+        };
+
+        _dbContext.AuditEntries.Add(auditEntry);
+        await _dbContext.SaveChangesAsync(ct);
+
+        _logger.LogDebug(
+            "Persisted {EventCategory}/{EventName} event to audit database",
+            evt.Category, evt.Name);
+    }
+}
+```
+
+Register the implementation:
+
+```csharp
+builder.Services.AddTransient<IEventSink, AuditDatabaseEventSink>();
+```

--- a/astro/src/content/docs/identityserver/reference/v8/services/token-service.md
+++ b/astro/src/content/docs/identityserver/reference/v8/services/token-service.md
@@ -1,0 +1,139 @@
+---
+title: "Token Service"
+description: Documentation for the ITokenService interface which is responsible for building the Token model for identity tokens and access tokens before they are signed and serialized.
+sidebar:
+  label: Token Service
+  order: 48
+---
+
+#### Duende.IdentityServer.Services.ITokenService
+
+The `ITokenService` is responsible for building the `Token` model for identity tokens and access tokens. This is a higher-level service than `ITokenCreationService`: it assembles the token's claims, lifetime, and signing key information, then delegates serialization to `ITokenCreationService`.
+
+Implement or override this service to customize how token models are constructed before they are signed and serialized.
+
+```csharp
+/// <summary>
+/// Responsible for building the Token model for identity tokens and access tokens.
+/// This is a higher-level service than ITokenCreationService: it assembles the
+/// token's claims, lifetime, and signing key information, then delegates serialization to
+/// ITokenCreationService.
+/// </summary>
+public interface ITokenService
+{
+    /// <summary>
+    /// Creates an identity token.
+    /// </summary>
+    /// <param name="request">The token creation request.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>An identity token.</returns>
+    Task<Token> CreateIdentityTokenAsync(TokenCreationRequest request, CancellationToken ct);
+
+    /// <summary>
+    /// Creates an access token.
+    /// </summary>
+    /// <param name="request">The token creation request.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>An access token.</returns>
+    Task<Token> CreateAccessTokenAsync(TokenCreationRequest request, CancellationToken ct);
+
+    /// <summary>
+    /// Creates a serialized and protected security token.
+    /// </summary>
+    /// <param name="token">The token.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A serialized security token (typically a JWT or reference token handle).</returns>
+    Task<string> CreateSecurityTokenAsync(Token token, CancellationToken ct);
+}
+```
+
+## ITokenService APIs
+
+* **`CreateIdentityTokenAsync(TokenCreationRequest request, CancellationToken ct)`**
+
+  Creates an identity token. The `DefaultTokenService` uses `IClaimsService` to determine which claims to include, applies token lifetime from the client configuration, and selects the appropriate signing credentials.
+
+* **`CreateAccessTokenAsync(TokenCreationRequest request, CancellationToken ct)`**
+
+  Creates an access token. The `DefaultTokenService` uses `IClaimsService` for claim assembly, sets the token lifetime, configures audiences, and applies DPoP or mTLS proof-of-possession confirmation if applicable.
+
+* **`CreateSecurityTokenAsync(Token token, CancellationToken ct)`**
+
+  Serializes and protects a token. For JWT access tokens and identity tokens, this delegates to `ITokenCreationService` to produce a signed JWT. For reference tokens, it stores the token via `IReferenceTokenStore` and returns a handle.
+
+## TokenCreationRequest
+
+The `TokenCreationRequest` class models the data needed to create a token from a validated request.
+
+* **`Subject`** — The `ClaimsPrincipal` representing the authenticated user.
+* **`ValidatedResources`** — The validated resources (scopes) requested.
+* **`ValidatedRequest`** — The validated protocol request.
+* **`IncludeAllIdentityClaims`** — Whether to include all identity claims in the token.
+* **`AccessTokenToHash`** — The access token value to hash for the `at_hash` claim in identity tokens.
+* **`AuthorizationCodeToHash`** — The authorization code value to hash for the `c_hash` claim.
+* **`StateHash`** — A pre-hashed state value for the `s_hash` claim.
+* **`Nonce`** — The nonce value from the authorization request.
+* **`Description`** — The description the user assigned to the device being authorized.
+
+## Default Implementation
+
+The `DefaultTokenService` orchestrates token creation by coordinating between `IClaimsService`, `IKeyMaterialService`, `IReferenceTokenStore`, and `ITokenCreationService`. Its constructor dependencies reflect this coordination:
+
+```csharp
+public DefaultTokenService(
+    IClaimsService claimsProvider,
+    IReferenceTokenStore referenceTokenStore,
+    ITokenCreationService creationService,
+    TimeProvider timeProvider,
+    IKeyMaterialService keyMaterialService,
+    IdentityServerOptions options,
+    ILogger<DefaultTokenService> logger)
+```
+
+## Relationship to Other Services
+
+| Service | Responsibility |
+|---------|---------------|
+| `IProfileService` | User-centric profile data (claims source) |
+| `IClaimsService` | Determines which claims to include in each token type |
+| **`ITokenService`** | **Builds the complete `Token` model** |
+| `ITokenCreationService` | Serializes the `Token` model into a JWT |
+
+## Sample Implementation
+
+The following example shows a custom token service that adds custom metadata to all access tokens:
+
+```csharp
+public class CustomTokenService : DefaultTokenService
+{
+    public CustomTokenService(
+        IClaimsService claimsProvider,
+        IReferenceTokenStore referenceTokenStore,
+        ITokenCreationService creationService,
+        TimeProvider timeProvider,
+        IKeyMaterialService keyMaterialService,
+        IdentityServerOptions options,
+        ILogger<DefaultTokenService> logger)
+        : base(claimsProvider, referenceTokenStore, creationService,
+               timeProvider, keyMaterialService, options, logger)
+    {
+    }
+
+    public override async Task<Token> CreateAccessTokenAsync(
+        TokenCreationRequest request, CancellationToken ct)
+    {
+        var token = await base.CreateAccessTokenAsync(request, ct);
+
+        // Add a custom claim to every access token
+        token.Claims.Add(new Claim("token_version", "2.0"));
+
+        return token;
+    }
+}
+```
+
+Register the implementation:
+
+```csharp
+builder.Services.AddTransient<ITokenService, CustomTokenService>();
+```

--- a/astro/src/content/docs/identityserver/reference/v8/stores/index.md
+++ b/astro/src/content/docs/identityserver/reference/v8/stores/index.md
@@ -15,12 +15,48 @@ Stores in IdentityServer are the persistence layer abstractions responsible for 
 for the authentication and authorization processes. They provide interfaces to store and retrieve configuration and
 operational data.
 
-Common types of stores include:
+## Configuration Stores
 
-* Client store - manages client application registrations
-* Resource store - handles API resources and scopes
-* Persisted grant store - maintains operational data like authorization codes and refresh tokens
-* User store - manages user authentication data (typically integrated with ASP.NET Identity)
+Configuration stores manage the relatively static data that defines how IdentityServer behaves:
 
-IdentityServer provides default in-memory implementations of these stores for development scenarios, and extensibility
-points to implement custom stores using various database technologies for production environments.
+| Store | Purpose |
+|-------|---------|
+| [IClientStore](/identityserver/reference/v8/stores/client-store.md) | Client application registrations |
+| [IResourceStore](/identityserver/reference/v8/stores/resource-store.md) | API resources, API scopes, and identity resources |
+| [IIdentityProviderStore](/identityserver/reference/v8/stores/idp-store.md) | Dynamic external identity providers |
+| [ICorsPolicyService](/identityserver/reference/v8/stores/cors-policy-service.md) | CORS origin validation for clients |
+
+## Operational Stores
+
+Operational stores manage transient, runtime data that supports active authentication flows:
+
+| Store | Purpose |
+|-------|---------|
+| [IPersistedGrantStore](/identityserver/reference/v8/stores/persisted-grant-store.md) | Authorization codes, refresh tokens, reference tokens, and user consent |
+| [IDeviceFlowStore](/identityserver/reference/v8/stores/device-flow-store.md) | Device authorization grant data |
+| [IBackChannelAuthenticationRequestStore](/identityserver/reference/v8/stores/backchannel-auth-request-store.md) | CIBA authentication requests |
+| [IPushedAuthorizationRequestStore](/identityserver/reference/v8/stores/pushed-authorization-request-store.md) | Pushed Authorization Requests (PAR) |
+| [IServerSideSessionStore](/identityserver/reference/v8/stores/server-side-sessions.md) | Server-side user sessions |
+| [ISigningKeyStore](/identityserver/reference/v8/stores/signing-key-store.md) | Automatic key management signing keys |
+
+## Key Management Stores
+
+These stores provide signing and validation keys to the runtime:
+
+| Store | Purpose |
+|-------|---------|
+| `ISigningCredentialStore` | Provides the active signing credential for token signing |
+| `IValidationKeysStore` | Provides all public keys for token validation (published via JWKS) |
+
+## In-Memory Implementations
+
+IdentityServer provides default in-memory implementations suitable for development and testing. These are registered via the DI extension methods:
+
+```csharp
+builder.Services.AddIdentityServer()
+    .AddInMemoryClients(Config.Clients)
+    .AddInMemoryApiScopes(Config.ApiScopes)
+    .AddInMemoryIdentityResources(Config.IdentityResources);
+```
+
+For production environments, use the [Entity Framework Core integration](/identityserver/data/ef.md) or implement custom stores using your preferred database technology.

--- a/astro/src/content/docs/identityserver/reference/v8/validators/redirect-uri-validator.md
+++ b/astro/src/content/docs/identityserver/reference/v8/validators/redirect-uri-validator.md
@@ -8,6 +8,7 @@ redirect_from:
   - /identityserver/v5/reference/validators/redirect_uri_validator/
   - /identityserver/v6/reference/validators/redirect_uri_validator/
   - /identityserver/reference/validators/redirect-uri-validator/
+  - /identityserver/reference/v8/validators/redirect_uri_validator/
 ---
 
 #### Duende.IdentityServer.Validation.IRedirectUriValidator


### PR DESCRIPTION
Add detailed API documentation for `IClaimsService`, `IEventSink`, and `ITokenService`. Include descriptions of default implementations and examples for customization. Also, update information regarding response handling, stores, device flow interaction, CIBA user notification, and EF operational options as part of the v8 release documentation.