### PR TITLE
Expand SAML documentation with additional details

### DIFF
--- a/astro/src/content/docs/identityserver/diagnostics/events.md
+++ b/astro/src/content/docs/identityserver/diagnostics/events.md
@@ -168,6 +168,10 @@ The following events are raised by SAML components:
 
   Raised when validation of an incoming SAML logout request fails.
 
+* **`InvalidSamlServiceProviderConfigurationEvent`**
+
+  Raised when a SAML Service Provider's configuration fails runtime validation (performed by [`ISamlServiceProviderConfigurationValidator`](/identityserver/saml/extensibility#isamlserviceproviderconfigurationvalidator)). Includes the SP's `EntityId` and `DisplayName`.
+
 ### Custom events
 
 You can create your own events and emit them via our infrastructure.

--- a/astro/src/content/docs/identityserver/saml/configuration.md
+++ b/astro/src/content/docs/identityserver/saml/configuration.md
@@ -90,7 +90,7 @@ Available options:
 * **`DefaultSigningBehavior`**
   Default signing behavior for SAML responses. Defaults to `SignAssertion`.
 
-  The default is `SignAssertion` for backward compatibility with existing deployments and SPs that expect only the assertion to be signed. For new deployments, `SignResponse` is recommended because it signs the entire SAML response — including the assertion — providing integrity protection over the full message. See [`SamlSigningBehavior`](#samlsigningbehavior) for details on each option.
+  The default is `SignAssertion` for backward compatibility with existing deployments and SPs that expect only the assertion to be signed. For new deployments, `SignResponse` is recommended because it signs the entire SAML response (including the assertion), providing integrity protection over the full message. See [`SamlSigningBehavior`](#samlsigningbehavior) for details on each option.
 
   :::note
   SAML signing requires an X509 certificate. When you use automatic key management or `AddDeveloperSigningCredential()` (which provide RSA keys without a certificate), IdentityServer automatically generates an X509 container that wraps your existing RSA key material. You do not need to create or provide a certificate manually.

--- a/astro/src/content/docs/identityserver/saml/configuration.md
+++ b/astro/src/content/docs/identityserver/saml/configuration.md
@@ -90,6 +90,8 @@ Available options:
 * **`DefaultSigningBehavior`**
   Default signing behavior for SAML responses. Defaults to `SignAssertion`.
 
+  The default is `SignAssertion` for backward compatibility with existing deployments and SPs that expect only the assertion to be signed. For new deployments, `SignResponse` is recommended because it signs the entire SAML response — including the assertion — providing integrity protection over the full message. See [`SamlSigningBehavior`](#samlsigningbehavior) for details on each option.
+
   :::note
   SAML signing requires an X509 certificate. When you use automatic key management or `AddDeveloperSigningCredential()` (which provide RSA keys without a certificate), IdentityServer automatically generates an X509 container that wraps your existing RSA key material. You do not need to create or provide a certificate manually.
   :::
@@ -171,15 +173,15 @@ builder.Services.AddIdentityServer()
 
 `SamlEndpointOptions` configures the URL paths and supported bindings for all SAML protocol endpoints. Access it via `SamlOptions.Endpoints`.
 
-| Property                      | Type                  | Default                    | Description                                                                                                                                           |
-|-------------------------------|-----------------------|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `SingleSignOnServicePath`     | `string`              | `"/Saml2/SSO"`             | Path for the SSO endpoint (receives AuthnRequests).                                                                                                   |
-| `SingleSignOnServiceBindings` | `ICollection<string>` | `[HttpRedirect, HttpPost]` | Bindings advertised in metadata for the SSO endpoint. This controls what appears in the metadata document, not whether the endpoint accepts requests. |
-| `SingleSignOnCallbackPath`    | `string`              | `"/Saml2/SSO/Callback"`    | Path for the SSO callback endpoint (after user authenticates). This is an internal endpoint that is not visible in the metadata document.             |
-| `SingleLogoutServicePath`     | `string`              | `"/Saml2/SLO"`             | Path for the SLO endpoint (receives LogoutRequests and LogoutResponses).                                                                              |
-| `SingleLogoutServiceBindings` | `ICollection<string>` | `[HttpRedirect, HttpPost]` | Bindings advertised in metadata for the SLO endpoint. This controls what appears in the metadata document, not whether the endpoint accepts requests. |
-| `SingleLogoutCallbackPath`    | `string`              | `"/Saml2/SLO/Callback"`    | Path for the SLO callback endpoint (completes the logout flow). This is an internal endpoint that is not visible in the metadata document.            |
-| `StateIdParameterName`        | `string`              | `"samlStateId"`            | Query string parameter name used to pass the SAML sign-in state identifier through the return URL in the redirect to the login page.                  |
+| Property                      | Type                  | Default                    | Description                                                                                                                                                                                                                                                             |
+|-------------------------------|-----------------------|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `SingleSignOnServicePath`     | `string`              | `"/Saml2/SSO"`             | Path for the SSO endpoint (receives AuthnRequests).                                                                                                                                                                                                                     |
+| `SingleSignOnServiceBindings` | `ICollection<string>` | `[HttpRedirect, HttpPost]` | Bindings advertised in metadata for the SSO endpoint. This controls what appears in the metadata document, not whether the endpoint accepts requests.                                                                                                                   |
+| `SingleSignOnCallbackPath`    | `string`              | `"/Saml2/SSO/Callback"`    | Path for the SSO callback endpoint (after user authenticates). This is an internal endpoint that is not visible in the metadata document.                                                                                                                               |
+| `SingleLogoutServicePath`     | `string`              | `"/Saml2/SLO"`             | Path for the SLO endpoint (receives LogoutRequests and LogoutResponses).                                                                                                                                                                                                |
+| `SingleLogoutServiceBindings` | `ICollection<string>` | `[HttpRedirect, HttpPost]` | Bindings advertised in metadata for the SLO endpoint. This controls what appears in the metadata document, not whether the endpoint accepts requests. Note: SP-side SLO endpoints (`SamlServiceProvider.SingleLogoutServiceUrls`) currently only support HTTP Redirect. |
+| `SingleLogoutCallbackPath`    | `string`              | `"/Saml2/SLO/Callback"`    | Path for the SLO callback endpoint (completes the logout flow). This is an internal endpoint that is not visible in the metadata document.                                                                                                                              |
+| `StateIdParameterName`        | `string`              | `"samlStateId"`            | Query string parameter name used to pass the SAML sign-in state identifier through the return URL in the redirect to the login page.                                                                                                                                    |
 
 
 ```csharp
@@ -295,10 +297,10 @@ SAML bindings define how messages travel over HTTP. HTTP Redirect encodes the me
 
 `SamlBinding` is used on `SamlEndpointType` (for each entry in `SingleLogoutServiceUrls`) and on the derived `IndexedEndpoint` (for each ACS endpoint in `AssertionConsumerServiceUrls`).
 
-| Value          | Description                                                                           |
-|----------------|---------------------------------------------------------------------------------------|
+| Value          | Description                                                           |
+|----------------|-----------------------------------------------------------------------|
 | `HttpRedirect` | HTTP Redirect binding. The SAML message is sent as a query parameter. |
-| `HttpPost`     | HTTP POST binding. The SAML message is sent in an HTML form.       |
+| `HttpPost`     | HTTP POST binding. The SAML message is sent in an HTML form.          |
 
 ### SamlSigningBehavior
 
@@ -424,7 +426,8 @@ new SamlServiceProvider
 ```
 
 :::caution
-IdP-initiated SSO is inheritly vulnerable to Cross Site Request Forgery (CSRF). This is a property of the protocol, there is no way to enable or implement it without exposing CSRF risk.
+IdP-initiated SSO is inherently vulnerable to Cross-Site Request Forgery (CSRF). This is a property of the protocol, 
+there is no way to enable or implement it without exposing CSRF risk.
 
 A better approach is to mimic the third-party initiated login flow used by OIDC: create an endpoint on the SP that responds with a redirect to the IdP, including an `AuthnRequest`.
 

--- a/astro/src/content/docs/identityserver/saml/extensibility.md
+++ b/astro/src/content/docs/identityserver/saml/extensibility.md
@@ -218,7 +218,13 @@ public interface ISaml2SloResponseGenerator
 
 ### When to Use
 
-Override `ISaml2SloResponseGenerator` if you are not using the built-in EF-based operational store. The in-memory version is only suitable for development/test scenarios and not for production.
+Override `ISaml2SloResponseGenerator` to customize the SAML `LogoutResponse` XML that IdentityServer sends back to the SP that initiated the SLO flow. Common reasons include:
+
+- Changing the response status code or sub-status codes based on custom business logic
+- Adding SAML extensions to the `LogoutResponse` element
+- Altering how partial-logout scenarios are reported (e.g., always returning success even when some SPs failed to respond)
+
+This interface controls **response generation**, not persistence. To customize how logout session state is stored, see [`ISamlLogoutSessionStore`](#isamllogoutsessionstore).
 
 ### Registration
 
@@ -244,8 +250,7 @@ instances.
 IdentityServer automatically registers an EF Core-backed implementation. No additional configuration
 is needed.
 
-**Custom implementation:** You can register your own implementation using the `AddSamlLogoutSessionStore<T>()` extension
-method on the IdentityServer builder. Use this when you need a specific persistence backend such as
+**Custom implementation:** Register your own implementation directly in the DI container before calling `AddSaml()`. Use this when you need a specific persistence backend such as
 Redis or DynamoDB, or when you're not using the EF operational store.
 
 Expired logout sessions are removed automatically by `TokenCleanupService`. The lifetime of each
@@ -303,9 +308,9 @@ You can register your custom store at startup:
 
 ```csharp
 // Program.cs
+builder.Services.AddScoped<ISamlLogoutSessionStore, CustomDistributedSamlLogoutSessionStore>();
 builder.Services.AddIdentityServer()
-    .AddSaml()
-    .AddSamlLogoutSessionStore<CustomDistributedSamlLogoutSessionStore>();
+    .AddSaml();
 ```
 
 ---
@@ -600,6 +605,7 @@ public interface ISamlSigningService
 {
     Task<X509Certificate2> GetSigningCertificateAsync(CancellationToken ct);
     Task<string> GetSigningCertificateBase64Async(CancellationToken ct);
+    Task<IReadOnlyList<X509Certificate2>> GetAllSigningCertificatesAsync(CancellationToken ct);
 }
 ```
 
@@ -608,6 +614,9 @@ public interface ISamlSigningService
   the credential is not an X.509 certificate or RSA key, or if the certificate has no private key.
 * `GetSigningCertificateBase64Async` - returns the base64-encoded DER representation of the
   certificate, used when embedding the certificate in SAML metadata key descriptors.
+* `GetAllSigningCertificatesAsync` - returns all available signing certificates, including any
+  previously rotated keys that are still valid. Used by the metadata generator to publish multiple
+  key descriptors, allowing Service Providers to validate signatures during key rollover periods.
 
 The default implementation derives the certificate from IdentityServer's configured signing keys.
 When the active signing key is an `X509SecurityKey`, it uses the certificate directly. When the
@@ -901,6 +910,43 @@ public class CustomDistributedSamlSigninStateStore : ISamlSigninStateStore
             ct);
     }
 }
+```
+
+:::tip
+The example above uses `JsonSerializer` directly for simplicity. For production use, consider injecting [`ISamlSigninStateSerializer`](#isamlsigninstateserializer) instead, which provides the same serialization logic used by the built-in EF Core store and handles any custom `Extensions` content correctly.
+:::
+
+---
+
+## ISamlSigninStateSerializer
+
+`ISamlSigninStateSerializer` handles serialization and deserialization of `SamlAuthenticationState` for persistence. The default implementation is used by the Entity Framework Core store, but you can replace it to customize how SAML authentication state is serialized — for example, to support custom `Extensions` content or to use a different serialization format.
+
+```csharp
+// ISamlSigninStateSerializer.cs
+public interface ISamlSigninStateSerializer
+{
+    string Serialize(SamlAuthenticationState state);
+    SamlAuthenticationState Deserialize(string serializedState);
+}
+```
+
+* `Serialize`: converts a `SamlAuthenticationState` instance to a string representation for storage.
+* `Deserialize`: reconstructs a `SamlAuthenticationState` from its stored string representation.
+
+### When to Use
+
+Override `ISamlSigninStateSerializer` when:
+
+- You need to persist custom data stored in the `Extensions` property of `SamlAuthenticationState` and the default JSON serialization doesn't handle it correctly.
+- You want to use a different serialization format (e.g., binary, MessagePack) for performance or size reasons.
+- You're building a custom `ISamlSigninStateStore` and want to reuse the same serialization logic as the built-in EF store rather than writing your own.
+
+### Registration
+
+```csharp
+// Program.cs
+builder.Services.AddSingleton<ISamlSigninStateSerializer, CustomSamlSigninStateSerializer>();
 ```
 
 ---

--- a/astro/src/content/docs/identityserver/ui/login/dynamicproviders.md
+++ b/astro/src/content/docs/identityserver/ui/login/dynamicproviders.md
@@ -245,7 +245,7 @@ SAML dynamic providers use the `SamlProvider` model, which extends `IdentityProv
 * `IdpEntityId` (`string?`, default `null`) — The entity ID of the remote SAML Identity Provider.
 * `SingleSignOnServiceUrl` (`string?`, default `null`) — The URL of the IdP's SSO endpoint.
 * `SingleLogoutServiceUrl` (`string?`, default `null`) — The URL of the IdP's SLO endpoint. When `null`, outbound logout is disabled.
-* `SigningCertificateBase64` (`string?`, default `null`) — Base64-encoded X.509 certificate for validating IdP signatures.
+* `SigningCertificateBase64` (`string?`, default `null`) — Base64-encoded X.509 certificate for validating IdP signatures. This is singular because each dynamic provider record represents one IdP configuration. For key rollover with dynamic providers, update the record with the new certificate. In contrast, the [static SAML provider](/identityserver/ui/login/saml-provider) uses `SigningCertificatesBase64` (a list) to support multiple certificates simultaneously during rollover periods.
 * `BindingType` (`string`, default `"redirect"`) — The SAML binding type (`"redirect"` or `"post"`).
 * `SpEntityId` (`string?`, default `null`) — The entity ID of your application (the SP). When `null`, derived from the IdentityServer issuer.
 * `AllowUnsolicitedAuthnResponse` (`bool`, default `false`) — Whether to accept IdP-initiated (unsolicited) responses.


### PR DESCRIPTION
Enhance the SAML documentation with the following updates:
- Add information about new events and extensibility options.
- Include details on key rollover and default signing behavior.
- Document the customization of `ISamlSigninStateSerializer`.