### PR TITLE
Add migration guide for RSK SAML to Duende IdentityServer

### DIFF
--- a/astro/src/content/docs/identityserver/saml/index.md
+++ b/astro/src/content/docs/identityserver/saml/index.md
@@ -11,6 +11,10 @@ sidebar:
 This feature is part of the [Duende IdentityServer Enterprise (legacy), Standard (add-on), Advanced, and Custom Edition](https://duendesoftware.com/products/identityserver).
 :::
 
+:::tip[Migrating from Rock Solid Knowledge SAML?]
+If you're upgrading from the Rock Solid Knowledge (RSK) SAML addon (`Rsk.Saml.DuendeIdentityServer`) to Duende IdentityServer's built-in SAML support, see the dedicated [RSK SAML Migration Guide](/identityserver/upgrades/rsk-saml-to-duende-identityserver.md).
+:::
+
 IdentityServer can act as a **SAML 2.0 Identity Provider (IdP)**, issuing SAML assertions to
 Service Providers (SPs). This enables integration with enterprise applications and legacy systems
 that use the SAML 2.0 protocol rather than OAuth 2.0 / OpenID Connect.

--- a/astro/src/content/docs/identityserver/upgrades/index.md
+++ b/astro/src/content/docs/identityserver/upgrades/index.md
@@ -19,6 +19,7 @@ Migrations.
 
 * [**IdentityServer v7.4 to v8.0**](/identityserver/upgrades/v7_4-to-v8_0.md)
 * [**IdentityServer4 to Duende IdentityServer v8**](/identityserver/upgrades/identityserver4-to-duende-identityserver-v8.mdx)
+* [**Rock Solid Knowledge SAML to Duende IdentityServer**](/identityserver/upgrades/rsk-saml-to-duende-identityserver.md) - Migrate from the Rock Solid Knowledge (RSK) SAML addon to Duende IdentityServer v8+ built-in SAML support.
 
 ## Upgrading to v7.0
 

--- a/astro/src/content/docs/identityserver/upgrades/index.md
+++ b/astro/src/content/docs/identityserver/upgrades/index.md
@@ -19,7 +19,7 @@ Migrations.
 
 * [**IdentityServer v7.4 to v8.0**](/identityserver/upgrades/v7_4-to-v8_0.md)
 * [**IdentityServer4 to Duende IdentityServer v8**](/identityserver/upgrades/identityserver4-to-duende-identityserver-v8.mdx)
-* [**Rock Solid Knowledge SAML to Duende IdentityServer**](/identityserver/upgrades/rsk-saml-to-duende-identityserver.md) - Migrate from the Rock Solid Knowledge (RSK) SAML addon to Duende IdentityServer v8+ built-in SAML support.
+* [**Migrate from the Rock Solid Knowledge (RSK) SAML addon to Duende IdentityServer built-in SAML support**](/identityserver/upgrades/rsk-saml-to-duende-identityserver.md)
 
 ## Upgrading to v7.0
 

--- a/astro/src/content/docs/identityserver/upgrades/rsk-saml-to-duende-identityserver.md
+++ b/astro/src/content/docs/identityserver/upgrades/rsk-saml-to-duende-identityserver.md
@@ -1,0 +1,438 @@
+---
+title: "Rock Solid Knowledge SAML to Duende IdentityServer SAML"
+description: "Step-by-step guide to migrate from Rock Solid Knowledge (RSK) SAML (Rsk.Saml.DuendeIdentityServer) to Duende IdentityServer v8+ built-in SAML 2.0 Identity Provider support."
+sidebar:
+  order: 138
+  label: RSK SAML → Duende SAML
+---
+
+:::note
+This guide covers migrating from Rock Solid Knowledge (RSK) SAML (`Rsk.Saml.DuendeIdentityServer`) to Duende IdentityServer's built-in SAML 2.0 Identity Provider support. SAML requires the [Standard Edition (with SAML add-on), Advanced, or Custom Edition](https://duendesoftware.com/products/identityserver). SAML is not available in Community Edition or Lite.
+:::
+
+This guide walks through migrating from **Rock Solid Knowledge (RSK) SAML** (`Rsk.Saml.DuendeIdentityServer`) to **Duende IdentityServer v8+** with built-in SAML support.
+
+## Overview
+
+### What Changed
+
+| Aspect       | RSK SAML                                   | Duende SAML (v8+)                                |
+|--------------|--------------------------------------------|--------------------------------------------------|
+| Package      | `Rsk.Saml.DuendeIdentityServer` (separate) | Built into `Duende.IdentityServer`               |
+| .NET Version | .NET 8 (v11.x), .NET 10 (v12.x)            | .NET 10+ required                                |
+| License      | Separate RSK SAML license                  | Included in Advanced/Custom; add-on for Standard |
+| Registration | `.AddSamlPlugin()`                         | `.AddSaml()`                                     |
+| Middleware   | `.UseIdentityServerSamlPlugin()` required  | Not needed                                       |
+| SSO Endpoint | `/saml/sso`                                | `/Saml2/SSO`                                     |
+| SLO Endpoint | `/saml/slo`                                | `/Saml2/SLO`                                     |
+| Metadata     | `/saml/metadata`                           | `/Saml2`                                         |
+
+### Why Migrate?
+
+- **Unified licensing**: One Duende license covers all features; SAML included in Advanced/Custom or available as Standard add-on
+- **Built-in support**: No separate package dependency to manage
+- **Consistent updates**: SAML features ship with core IdentityServer releases
+- **Better integration**: Tighter coupling with IdentityServer's core services
+
+## Prerequisites
+
+Before migrating, ensure:
+
+1. **Duende License with SAML**: SAML is included in Advanced and Custom editions, or available as a [Standard Edition add-on](https://duendesoftware.com/products/identityserver)
+2. **.NET 10 SDK**: Duende v8+ requires .NET 10
+3. **Backup**: Export your current SAML Service Provider (SP) configurations
+4. **Test Environment**: Set up a test environment before production migration
+
+## Step 1: Update Target Framework
+
+Duende IdentityServer v8+ requires .NET 10:
+
+```diff lang="xml" title=".csproj"
+- <TargetFramework>net8.0</TargetFramework>
++ <TargetFramework>net10.0</TargetFramework>
+```
+
+## Step 2: Replace NuGet Packages
+
+```diff lang="xml" title=".csproj"
+- <PackageReference Include="Duende.IdentityServer" Version="7.4.3" />
+- <PackageReference Include="Rsk.Saml.DuendeIdentityServer" Version="11.0.0" />
++ <PackageReference Include="Duende.IdentityServer" Version="8.0.0" />
++ <!-- No separate SAML package needed! -->
+```
+
+## Step 3: Update Namespaces
+
+```diff lang="csharp" title="*.cs"
+- using Rsk.Saml;
+- using Rsk.Saml.Configuration;
+- using Rsk.Saml.Models;
+- using Rsk.Saml.Services;
++ using Duende.IdentityServer;
++ using Duende.IdentityServer.Models;
++ using Duende.IdentityServer.Saml;
++ using Duende.IdentityServer.Saml.Models;
+```
+
+## Step 4: Update Service Registration
+
+**Before (RSK):**
+
+```csharp title="Program.cs"
+builder.Services.AddIdentityServer()
+    .AddSamlPlugin(options =>
+    {
+        options.Licensee = "Your Licensee";
+        options.LicenseKey = "Your License Key";
+        options.WantAuthenticationRequestsSigned = false;
+    });
+```
+
+**After (Duende):**
+
+```csharp title="Program.cs"
+builder.Services.AddIdentityServer()
+    .AddSaml(saml =>
+    {
+        saml.WantAuthnRequestsSigned = false;
+        saml.DefaultSigningBehavior = SamlSigningBehavior.SignAssertion;
+        saml.DefaultClockSkew = TimeSpan.FromMinutes(5);
+        saml.DefaultAssertionLifetime = TimeSpan.FromMinutes(5);
+        
+        // Metadata configuration
+        saml.Metadata.CacheDuration = TimeSpan.FromHours(12);
+        saml.Metadata.ExpiryDuration = TimeSpan.FromDays(5);
+    });
+```
+
+## Step 5: Remove SAML Middleware
+
+```diff lang="csharp" title="Program.cs"
+- app.UseIdentityServer()
+-     .UseIdentityServerSamlPlugin();
++ app.UseIdentityServer();
+```
+
+Forgetting to remove `.UseIdentityServerSamlPlugin()` will cause a compilation error.
+
+## Step 6: Migrate Service Provider Configuration
+
+This is the most complex part. See [Service Provider Configuration Changes](#service-provider-configuration) for the full before/after comparison.
+
+## Step 7: Migrate Data (if using database stores)
+
+:::note[Database Migration]
+If your Service Provider configurations are stored in a database, you will need to migrate that data to Duende's new SAML tables. The [v7.4 to v8.0 upgrade guide](/identityserver/upgrades/v7_4-to-v8_0.md#step-3-update-database-schema) documents the new table schemas. Plan your data migration strategy accordingly.
+:::
+
+## API Mapping Reference
+
+### Extension Methods
+
+| RSK SAML                         | Duende SAML             |
+|----------------------------------|-------------------------|
+| `.AddSamlPlugin(options => { })` | `.AddSaml(saml => { })` |
+| `.UseIdentityServerSamlPlugin()` | Not needed              |
+
+### SAML Options
+
+| RSK (`SamlIdpOptions`)             | Duende (`SamlOptions`)                       |
+|------------------------------------|----------------------------------------------|
+| `WantAuthenticationRequestsSigned` | `WantAuthnRequestsSigned`                    |
+| `Licensee`                         | N/A (use `IdentityServerOptions.LicenseKey`) |
+| `LicenseKey`                       | N/A (use `IdentityServerOptions.LicenseKey`) |
+| —                                  | `DefaultAssertionLifetime` (NEW)             |
+| —                                  | `Metadata.CacheDuration` (NEW)               |
+| —                                  | `Metadata.ExpiryDuration` (NEW)              |
+
+### Service Provider Model
+
+| RSK (`ServiceProvider`)               | Duende (`SamlServiceProvider`)  |
+|---------------------------------------|---------------------------------|
+| `EntityId`                            | `EntityId`                      |
+| `AssertionConsumerServices`           | `AssertionConsumerServiceUrls`  |
+| `SingleLogoutServices`                | `SingleLogoutServiceUrls`       |
+| `ClaimsMapping`                       | `ClaimMappings`                 |
+| `SignAssertions` (bool)               | `SigningBehavior` (enum)        |
+| `EncryptAssertions`                   | `EncryptAssertions`             |
+| `RequireAuthenticationRequestsSigned` | `RequireSignedAuthnRequests`    |
+| `AllowIdpInitiatedSso`                | `AllowIdpInitiated`             |
+| —                                     | `AllowedScopes` (NEW, required) |
+| —                                     | `Enabled` (NEW)                 |
+| —                                     | `DisplayName` (NEW)             |
+
+### Endpoint Classes
+
+| RSK                                       | Duende                                                      |
+|-------------------------------------------|-------------------------------------------------------------|
+| `Service(binding, url)`                   | `IndexedEndpoint` (for ACS) or `SamlEndpointType` (for SLO) |
+| `SamlConstants.BindingTypes.HttpPost`     | `SamlBinding.HttpPost`                                      |
+| `SamlConstants.BindingTypes.HttpRedirect` | `SamlBinding.HttpRedirect`                                  |
+
+Duende uses two different endpoint types:
+- **`IndexedEndpoint`**: For ACS endpoints. Includes `Index` and `IsDefault` properties for SAML endpoint indexing.
+- **`SamlEndpointType`**: For SLO endpoints. A simpler type with just `Location` and `Binding`.
+
+## Service Provider Configuration
+
+### RSK Service Provider (Before)
+
+```csharp
+using Rsk.Saml;
+using Rsk.Saml.Models;
+
+public static IEnumerable<ServiceProvider> ServiceProviders =>
+[
+    new Rsk.Saml.Models.ServiceProvider
+    {
+        EntityId = "https://sp.example.com/saml",
+        
+        AssertionConsumerServices =
+        [
+            new Service(SamlConstants.BindingTypes.HttpPost, "https://sp.example.com/Saml2/Acs")
+        ],
+        
+        SingleLogoutServices =
+        [
+            new Service(SamlConstants.BindingTypes.HttpPost, "https://sp.example.com/Saml2/Logout")
+        ],
+        
+        ClaimsMapping = new Dictionary<string, string>
+        {
+            [ClaimTypes.Name] = ClaimTypes.Name,
+            [ClaimTypes.Email] = ClaimTypes.Email,
+        },
+        
+        SignAssertions = true,
+        EncryptAssertions = false,
+        RequireAuthenticationRequestsSigned = false,
+        AllowIdpInitiatedSso = true
+    }
+];
+```
+
+### Duende Service Provider (After)
+
+```csharp
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Saml;
+using Duende.IdentityServer.Saml.Models;
+
+public static IEnumerable<SamlServiceProvider> SamlServiceProviders =>
+[
+    new SamlServiceProvider
+    {
+        EntityId = "https://sp.example.com/saml",
+        DisplayName = "Example Service Provider",
+        Enabled = true,
+        
+        AssertionConsumerServiceUrls =
+        [
+            new IndexedEndpoint
+            {
+                Location = "https://sp.example.com/Saml2/Acs",
+                Binding = SamlBinding.HttpPost,
+                Index = 0,
+                IsDefault = true
+            }
+        ],
+        
+        SingleLogoutServiceUrls =
+        [
+            new SamlEndpointType
+            {
+                Location = "https://sp.example.com/Saml2/Logout",
+                Binding = SamlBinding.HttpRedirect // Note: Only HttpRedirect is supported for SLO
+            }
+        ],
+        
+        ClaimMappings = new Dictionary<string, string>
+        {
+            [ClaimTypes.Name] = ClaimTypes.Name,
+            [ClaimTypes.Email] = ClaimTypes.Email,
+        },
+        
+        SigningBehavior = SamlSigningBehavior.SignAssertion,
+        EncryptAssertions = false,
+        RequireSignedAuthnRequests = false,
+        AllowIdpInitiated = true,
+        
+        // NEW: Required for Duende
+        AllowedScopes = ["openid", "profile", "email"]
+    }
+];
+```
+
+## Breaking Changes
+
+### `AllowedScopes` is Required
+
+Duende requires `AllowedScopes` to be set on each SAML Service Provider (SP). Without it, the Service Provider will fail runtime validation.
+
+```csharp
+// REQUIRED - will fail validation without this
+AllowedScopes = ["openid", "profile", "email"]
+```
+
+`AllowedScopes` determines which claims can be included in SAML assertions. Include the identity resource names that contain the claim types your Service Provider needs:
+
+| If SP needs these claims            | Include this scope                 |
+|-------------------------------------|------------------------------------|
+| `sub` (subject identifier)          | `openid`                           |
+| `name`, `family_name`, `given_name` | `profile`                          |
+| `email`, `email_verified`           | `email`                            |
+| Custom claims                       | Your custom identity resource name |
+
+### ACS Binding Must Be HttpPost
+
+All `AssertionConsumerServiceUrls` must use `SamlBinding.HttpPost`. HTTP-Redirect is not supported for SAML Response delivery because SAML responses containing signed assertions are typically too large for URL-based transport.
+
+Duende IdentityServer enforces this at runtime via `DefaultSamlServiceProviderConfigurationValidator`. If you configure an ACS endpoint with any other binding, the Service Provider will fail validation and be rejected with an error like:
+
+> Assertion Consumer Service at index 0 uses an unsupported binding 'HttpRedirect'. Only HTTP-POST is supported for SAML Response delivery.
+
+```csharp
+// ✅ CORRECT
+new IndexedEndpoint
+{
+    Binding = SamlBinding.HttpPost,
+    Location = "https://sp.example.com/Saml2/Acs",
+    Index = 0,
+    IsDefault = true
+}
+
+// ❌ WRONG - will fail runtime validation
+new IndexedEndpoint
+{
+    Binding = SamlBinding.HttpRedirect, // Not supported for ACS
+    Location = "https://sp.example.com/Saml2/Acs",
+    Index = 0,
+    IsDefault = true
+}
+```
+
+### SLO Binding Must Be HttpRedirect
+
+Unlike ACS endpoints, Single Logout (SLO) endpoints must use `SamlBinding.HttpRedirect`. HTTP-POST is not supported for SLO because it would require `SameSite=None` cookies, which introduces security concerns in cross-site iframe scenarios.
+
+If your RSK configuration used `HttpPost` for SLO, you must change it:
+
+```diff lang="csharp"
+- new Service(SamlConstants.BindingTypes.HttpPost, "https://sp.example.com/Saml2/Logout")
++ new SamlEndpointType
++ {
++     Location = "https://sp.example.com/Saml2/Logout",
++     Binding = SamlBinding.HttpRedirect
++ }
+```
+
+### Endpoint URL Paths Changed
+
+| RSK Path         | Duende Path  |
+|------------------|--------------|
+| `/saml/sso`      | `/Saml2/SSO` |
+| `/saml/slo`      | `/Saml2/SLO` |
+| `/saml/metadata` | `/Saml2`     |
+
+Update any Service Providers that have hardcoded these URLs.
+
+### Signing Behavior Changed from Bool to Enum
+
+```diff lang="csharp"
+- SignAssertions = true,
+- SignResponse = false,
++ SigningBehavior = SamlSigningBehavior.SignAssertion
+```
+
+Available values: `SignAssertion`, `SignResponse`, `SignBoth`, `DoNotSign`
+
+### License Configuration Changed
+
+RSK SAML had its own license. Duende uses a single license key:
+
+```diff lang="csharp" title="Program.cs"
+- .AddSamlPlugin(options =>
+- {
+-     options.Licensee = "...";
+-     options.LicenseKey = "...";
+- })
++ builder.Services.AddIdentityServer(options =>
++ {
++     options.LicenseKey = "your-duende-license-key";
++ });
+```
+
+### Property Naming Changes
+
+Watch for subtle naming differences:
+
+- `ClaimsMapping` → `ClaimMappings` (plural)
+- `AllowIdpInitiatedSso` → `AllowIdpInitiated` (shorter)
+- `RequireAuthenticationRequestsSigned` → `RequireSignedAuthnRequests` (reordered)
+
+## Testing Checklist
+
+After migration, verify:
+
+- [ ] Solution builds without errors
+- [ ] `/Saml2` returns valid SAML metadata XML
+- [ ] Metadata contains correct entity ID
+- [ ] Metadata contains correct ACS and SLO endpoints
+- [ ] Service Provider-initiated SSO flow works (SP → IdP → authenticate → SP)
+- [ ] Claims are correctly mapped in SAML assertions
+- [ ] Single Logout works (if configured)
+- [ ] IdP-initiated SSO works (if enabled)
+- [ ] Existing SAML integrations with live Service Providers still work
+- [ ] No license warnings in logs (valid SAML-enabled license active)
+
+### Quick Metadata Test
+
+```bash title="Terminal"
+curl -k https://localhost:5001/Saml2
+```
+
+## Troubleshooting
+
+### "Service Provider not found" Error
+
+The Service Provider's `EntityId` doesn't match what's registered. Check:
+
+1. Case sensitivity - entity IDs are case-sensitive
+2. Trailing slashes - `https://sp.example.com` ≠ `https://sp.example.com/`
+3. The Service Provider is registered with `Enabled = true`
+
+### "AllowedScopes is required" Error
+
+Add `AllowedScopes` to your Service Provider configuration:
+
+```csharp
+AllowedScopes = ["openid", "profile", "email"]
+```
+
+### "Unsupported binding" Error for ACS
+
+If you see an error like:
+
+> Assertion Consumer Service at index 0 uses an unsupported binding 'HttpRedirect'. Only HTTP-POST is supported for SAML Response delivery.
+
+Change your ACS endpoint binding to `SamlBinding.HttpPost`. HTTP-Redirect cannot be used for ACS because SAML responses with signed assertions exceed URL length limits.
+
+### Missing Claims in Assertion
+
+1. Check `ClaimMappings` dictionary
+2. Ensure claims exist on the user
+3. Verify `AllowedScopes` includes the relevant identity resources
+
+### SSO Works but SLO Fails
+
+1. Verify `SingleLogoutServiceUrls` is configured
+2. Ensure SLO binding is `SamlBinding.HttpRedirect` (HTTP-POST is not supported)
+3. Check that the Service Provider and IdP agree on the binding
+4. Ensure session management is properly configured
+
+## Related Resources
+
+- [SAML 2.0 Identity Provider Documentation](/identityserver/saml/)
+- [SAML Service Provider Configuration](/identityserver/saml/service-providers.md)
+- [SAML Endpoints Reference](/identityserver/saml/endpoints.md)
+- [v7.4 to v8.0 Upgrade Guide](/identityserver/upgrades/v7_4-to-v8_0.md)

--- a/astro/src/content/docs/identityserver/upgrades/rsk-saml-to-duende-identityserver.md
+++ b/astro/src/content/docs/identityserver/upgrades/rsk-saml-to-duende-identityserver.md
@@ -311,11 +311,13 @@ new IndexedEndpoint
 }
 ```
 
-### SLO Binding Must Be HttpRedirect
+### SLO Only Supports HttpRedirect
 
-Unlike ACS endpoints, Single Logout (SLO) endpoints must use `SamlBinding.HttpRedirect`. HTTP-POST is not supported for SLO because it would require `SameSite=None` cookies, which introduces security concerns in cross-site iframe scenarios.
+Single Logout (SLO) endpoints only support `SamlBinding.HttpRedirect`. Unlike ACS binding validation, this is **not checked at configuration time**. If you configure `HttpPost` for SLO, the configuration will load successfully, but SLO notifications will be **silently skipped** for that Service Provider at runtime.
 
-If your RSK configuration used `HttpPost` for SLO, you must change it:
+This happens because the SLO notification service specifically looks for an `HttpRedirect` endpoint. If none is found, it logs a debug message ("UnsupportedBinding") and skips the Service Provider without throwing an error.
+
+If your RSK configuration used `HttpPost` for SLO, change it to `HttpRedirect`:
 
 ```diff lang="csharp"
 - new Service(SamlConstants.BindingTypes.HttpPost, "https://sp.example.com/Saml2/Logout")
@@ -426,7 +428,7 @@ Change your ACS endpoint binding to `SamlBinding.HttpPost`. HTTP-Redirect cannot
 ### SSO Works but SLO Fails
 
 1. Verify `SingleLogoutServiceUrls` is configured
-2. Ensure SLO binding is `SamlBinding.HttpRedirect` (HTTP-POST is not supported)
+2. Ensure SLO binding is `SamlBinding.HttpRedirect` — if you configured `HttpPost`, SLO notifications will be silently skipped (check debug logs for "UnsupportedBinding")
 3. Check that the Service Provider and IdP agree on the binding
 4. Ensure session management is properly configured
 

--- a/astro/src/content/docs/identityserver/upgrades/rsk-saml-to-duende-identityserver.md
+++ b/astro/src/content/docs/identityserver/upgrades/rsk-saml-to-duende-identityserver.md
@@ -12,9 +12,7 @@ This guide covers migrating from Rock Solid Knowledge (RSK) SAML (`Rsk.Saml.Duen
 
 This guide walks through migrating from **Rock Solid Knowledge (RSK) SAML** (`Rsk.Saml.DuendeIdentityServer`) to **Duende IdentityServer v8+** with built-in SAML support.
 
-## Overview
-
-### What Changed
+## What Changed
 
 | Aspect       | RSK SAML                                   | Duende SAML (v8+)                                |
 |--------------|--------------------------------------------|--------------------------------------------------|
@@ -27,14 +25,16 @@ This guide walks through migrating from **Rock Solid Knowledge (RSK) SAML** (`Rs
 | SLO Endpoint | `/saml/slo`                                | `/Saml2/SLO`                                     |
 | Metadata     | `/saml/metadata`                           | `/Saml2`                                         |
 
-### Why Migrate?
+## Why Migrate?
 
 - **Unified licensing**: One Duende license covers all features; SAML included in Advanced/Custom or available as Standard add-on
 - **Built-in support**: No separate package dependency to manage
 - **Consistent updates**: SAML features ship with core IdentityServer releases
 - **Better integration**: Tighter coupling with IdentityServer's core services
 
-## Prerequisites
+## Migration Guide
+
+### Prerequisites
 
 Before migrating, ensure:
 
@@ -43,7 +43,7 @@ Before migrating, ensure:
 3. **Backup**: Export your current SAML Service Provider (SP) configurations
 4. **Test Environment**: Set up a test environment before production migration
 
-## Step 1: Update Target Framework
+### Step 1: Update Target Framework
 
 Duende IdentityServer v8+ requires .NET 10:
 
@@ -52,7 +52,7 @@ Duende IdentityServer v8+ requires .NET 10:
 + <TargetFramework>net10.0</TargetFramework>
 ```
 
-## Step 2: Replace NuGet Packages
+### Step 2: Replace NuGet Packages
 
 ```diff lang="xml" title=".csproj"
 - <PackageReference Include="Duende.IdentityServer" Version="7.4.3" />
@@ -61,7 +61,7 @@ Duende IdentityServer v8+ requires .NET 10:
 + <!-- No separate SAML package needed! -->
 ```
 
-## Step 3: Update Namespaces
+### Step 3: Update Namespaces
 
 ```diff lang="csharp" title="*.cs"
 - using Rsk.Saml;
@@ -74,7 +74,7 @@ Duende IdentityServer v8+ requires .NET 10:
 + using Duende.IdentityServer.Saml.Models;
 ```
 
-## Step 4: Update Service Registration
+### Step 4: Update Service Registration
 
 **Before (RSK):**
 
@@ -105,7 +105,7 @@ builder.Services.AddIdentityServer()
     });
 ```
 
-## Step 5: Remove SAML Middleware
+### Step 5: Remove SAML Middleware
 
 ```diff lang="csharp" title="Program.cs"
 - app.UseIdentityServer()
@@ -115,11 +115,11 @@ builder.Services.AddIdentityServer()
 
 Forgetting to remove `.UseIdentityServerSamlPlugin()` will cause a compilation error.
 
-## Step 6: Migrate Service Provider Configuration
+### Step 6: Migrate Service Provider Configuration
 
 This is the most complex part. See [Service Provider Configuration Changes](#service-provider-configuration) for the full before/after comparison.
 
-## Step 7: Migrate Data (if using database stores)
+### Step 7: Migrate Data (if using database stores)
 
 :::note[Database Migration]
 If your Service Provider configurations are stored in a database, you will need to migrate that data to Duende's new SAML tables. The [v7.4 to v8.0 upgrade guide](/identityserver/upgrades/v7_4-to-v8_0.md#step-3-update-database-schema) documents the new table schemas. Plan your data migration strategy accordingly.

--- a/astro/src/content/docs/identityserver/upgrades/rsk-saml-to-duende-identityserver.md
+++ b/astro/src/content/docs/identityserver/upgrades/rsk-saml-to-duende-identityserver.md
@@ -1,23 +1,22 @@
 ---
 title: "Rock Solid Knowledge SAML to Duende IdentityServer SAML"
-description: "Step-by-step guide to migrate from Rock Solid Knowledge (RSK) SAML (Rsk.Saml.DuendeIdentityServer) to Duende IdentityServer v8+ built-in SAML 2.0 Identity Provider support."
+description: "Step-by-step guide to migrate from Rock Solid Knowledge (RSK) SAML (Rsk.Saml.DuendeIdentityServer) to Duende IdentityServer built-in SAML 2.0 Identity Provider support."
 sidebar:
   order: 138
   label: RSK SAML → Duende SAML
 ---
 
 :::note
-This guide covers migrating from Rock Solid Knowledge (RSK) SAML (`Rsk.Saml.DuendeIdentityServer`) to Duende IdentityServer's built-in SAML 2.0 Identity Provider support. SAML requires the [Standard Edition (with SAML add-on), Advanced, or Custom Edition](https://duendesoftware.com/products/identityserver). SAML is not available in Community Edition or Lite.
+This guide covers migrating from Rock Solid Knowledge (RSK) SAML 2.0 (SAML2P) (`Rsk.Saml.DuendeIdentityServer`) to Duende IdentityServer's built-in SAML 2.0 Identity Provider support. SAML requires the [Standard Edition (with SAML add-on), Advanced, or Custom Edition](https://duendesoftware.com/products/identityserver). SAML is not available in Community Edition or Lite.
 :::
 
-This guide walks through migrating from **Rock Solid Knowledge (RSK) SAML** (`Rsk.Saml.DuendeIdentityServer`) to **Duende IdentityServer v8+** with built-in SAML support.
+This guide walks through migrating from **Rock Solid Knowledge (RSK) SAML** (`Rsk.Saml.DuendeIdentityServer`) to **Duende IdentityServer** with built-in SAML support.
 
 ## What Changed
 
-| Aspect       | RSK SAML                                   | Duende SAML (v8+)                                |
+| Aspect       | RSK SAML 2.0 (SAML2P)                                   | Duende SAML                                |
 |--------------|--------------------------------------------|--------------------------------------------------|
 | Package      | `Rsk.Saml.DuendeIdentityServer` (separate) | Built into `Duende.IdentityServer`               |
-| .NET Version | .NET 8 (v11.x), .NET 10 (v12.x)            | .NET 10+ required                                |
 | License      | Separate RSK SAML license                  | Included in Advanced/Custom; add-on for Standard |
 | Registration | `.AddSamlPlugin()`                         | `.AddSaml()`                                     |
 | Middleware   | `.UseIdentityServerSamlPlugin()` required  | Not needed                                       |
@@ -25,12 +24,6 @@ This guide walks through migrating from **Rock Solid Knowledge (RSK) SAML** (`Rs
 | SLO Endpoint | `/saml/slo`                                | `/Saml2/SLO`                                     |
 | Metadata     | `/saml/metadata`                           | `/Saml2`                                         |
 
-## Why Migrate?
-
-- **Unified licensing**: One Duende license covers all features; SAML included in Advanced/Custom or available as Standard add-on
-- **Built-in support**: No separate package dependency to manage
-- **Consistent updates**: SAML features ship with core IdentityServer releases
-- **Better integration**: Tighter coupling with IdentityServer's core services
 
 ## Migration Guide
 
@@ -38,7 +31,7 @@ This guide walks through migrating from **Rock Solid Knowledge (RSK) SAML** (`Rs
 
 Before migrating, ensure:
 
-1. **Duende License with SAML**: SAML is included in Advanced and Custom editions, or available as a [Standard Edition add-on](https://duendesoftware.com/products/identityserver)
+1. **Duende License with SAML support**: [see IdentityServer pricing page](https://duendesoftware.com/products/identityserver)
 2. **.NET 10 SDK**: Duende v8+ requires .NET 10
 3. **Backup**: Export your current SAML Service Provider (SP) configurations
 4. **Test Environment**: Set up a test environment before production migration
@@ -54,6 +47,7 @@ Duende IdentityServer v8+ requires .NET 10:
 
 ### Step 2: Replace NuGet Packages
 
+Duende IdentityServer includes all necessary SAML infrastructure. Make sure to use the latest version of IdentityServer, and remove references to RSK:
 ```diff lang="xml" title=".csproj"
 - <PackageReference Include="Duende.IdentityServer" Version="7.4.3" />
 - <PackageReference Include="Rsk.Saml.DuendeIdentityServer" Version="11.0.0" />
@@ -63,6 +57,7 @@ Duende IdentityServer v8+ requires .NET 10:
 
 ### Step 3: Update Namespaces
 
+Remove all RSK namespace references, and replace them with similar Duende namespaces:
 ```diff lang="csharp" title="*.cs"
 - using Rsk.Saml;
 - using Rsk.Saml.Configuration;
@@ -105,8 +100,9 @@ builder.Services.AddIdentityServer()
     });
 ```
 
-### Step 5: Remove SAML Middleware
+### Step 5: Remove RSK SAML Middleware
 
+The RSK SAML middleware is no longer required, and can be removed.
 ```diff lang="csharp" title="Program.cs"
 - app.UseIdentityServer()
 -     .UseIdentityServerSamlPlugin();
@@ -119,11 +115,9 @@ Forgetting to remove `.UseIdentityServerSamlPlugin()` will cause a compilation e
 
 This is the most complex part. See [Service Provider Configuration Changes](#service-provider-configuration) for the full before/after comparison.
 
-### Step 7: Migrate Data (if using database stores)
+### Step 7: Migrate Data (when using Entity Framework stores)
 
-:::note[Database Migration]
-If your Service Provider configurations are stored in a database, you will need to migrate that data to Duende's new SAML tables. The [v7.4 to v8.0 upgrade guide](/identityserver/upgrades/v7_4-to-v8_0.md#step-3-update-database-schema) documents the new table schemas. Plan your data migration strategy accordingly.
-:::
+If you are using Duende IdentityServer's Entity Framework stores for configuration and operational data, make sure to apply required database migrations. The [v7.4 to v8.0 upgrade guide](/identityserver/upgrades/v7_4-to-v8_0.md#step-3-update-database-schema) documents the updated database schema and migration aspects.
 
 ## API Mapping Reference
 

--- a/astro/src/content/docs/identityserver/upgrades/rsk-saml-to-duende-identityserver.md
+++ b/astro/src/content/docs/identityserver/upgrades/rsk-saml-to-duende-identityserver.md
@@ -14,12 +14,12 @@ This guide walks through migrating from **Rock Solid Knowledge (RSK) SAML** (`Rs
 
 ## What Changed
 
-| Aspect       | RSK SAML 2.0 (SAML2P)                                   | Duende SAML                                |
-|--------------|--------------------------------------------|--------------------------------------------------|
-| Package      | `Rsk.Saml.DuendeIdentityServer` (separate) | Built into `Duende.IdentityServer`               |
-| License      | Separate RSK SAML license                  | Included in Advanced/Custom; add-on for Standard |
-| Registration | `.AddSamlPlugin()`                         | `.AddSaml()`                                     |
-| Middleware   | `.UseIdentityServerSamlPlugin()` required  | Not needed                                       |
+| Aspect       | RSK SAML 2.0 (SAML2P)                      | Duende SAML                                                                              |
+|--------------|--------------------------------------------|------------------------------------------------------------------------------------------|
+| Package      | `Rsk.Saml.DuendeIdentityServer` (separate) | Built into `Duende.IdentityServer`                                                       |
+| License      | Separate RSK SAML license                  | Included in Advanced/Custom; add-on for Standard                                         |
+| Registration | `.AddSamlPlugin()`                         | `.AddSaml()`                                                                             |
+| Middleware   | `.UseIdentityServerSamlPlugin()` required  | Not needed                                                                               |
 | SSO Endpoint | `/saml/sso`                                | `/Saml2/SSO` ([configurable](/identityserver/saml/configuration.md#samlendpointoptions)) |
 | SLO Endpoint | `/saml/slo`                                | `/Saml2/SLO` ([configurable](/identityserver/saml/configuration.md#samlendpointoptions)) |
 | Metadata     | `/saml/metadata`                           | `/Saml2` ([configurable](/identityserver/saml/configuration.md#samlendpointoptions))     |
@@ -50,7 +50,7 @@ Duende IdentityServer includes all necessary SAML infrastructure. Make sure to u
 ```diff lang="xml" title=".csproj"
 - <PackageReference Include="Duende.IdentityServer" Version="7.4.3" />
 - <PackageReference Include="Rsk.Saml.DuendeIdentityServer" Version="11.0.0" />
-+ <PackageReference Include="Duende.IdentityServer" Version="8.0.0" />
++ <PackageReference Include="Duende.IdentityServer" Version="8.0.*" />
 + <!-- No separate SAML package needed! -->
 ```
 
@@ -167,6 +167,15 @@ Duende uses two different endpoint types:
 - **`SamlEndpointType`**: For SLO endpoints. A simpler type with just `Location` and `Binding`.
 
 ## Service Provider Configuration
+
+Each SAML Service Provider registered with your IdP must be migrated from the RSK `ServiceProvider` model to Duende's `SamlServiceProvider` model. The overall structure is similar, but there are key differences:
+
+- **New required property**: `AllowedScopes` must be set (see [Breaking Changes](#allowedscopes-is-required))
+- **Endpoint types changed**: RSK used a single `Service` class; Duende uses `IndexedEndpoint` for ACS and `SamlEndpointType` for SLO
+- **Signing behavior**: Changed from boolean (`SignAssertions`) to enum (`SigningBehavior`)
+- **New optional properties**: `DisplayName` and `Enabled` for better SP management
+
+See the [Service Provider Model](#service-provider-model) mapping table for a complete property-by-property comparison. The examples below show a full before/after comparison.
 
 ### RSK Service Provider (Before)
 

--- a/astro/src/content/docs/identityserver/upgrades/rsk-saml-to-duende-identityserver.md
+++ b/astro/src/content/docs/identityserver/upgrades/rsk-saml-to-duende-identityserver.md
@@ -20,9 +20,9 @@ This guide walks through migrating from **Rock Solid Knowledge (RSK) SAML** (`Rs
 | License      | Separate RSK SAML license                  | Included in Advanced/Custom; add-on for Standard |
 | Registration | `.AddSamlPlugin()`                         | `.AddSaml()`                                     |
 | Middleware   | `.UseIdentityServerSamlPlugin()` required  | Not needed                                       |
-| SSO Endpoint | `/saml/sso`                                | `/Saml2/SSO`                                     |
-| SLO Endpoint | `/saml/slo`                                | `/Saml2/SLO`                                     |
-| Metadata     | `/saml/metadata`                           | `/Saml2`                                         |
+| SSO Endpoint | `/saml/sso`                                | `/Saml2/SSO` ([configurable](/identityserver/saml/configuration.md#samlendpointoptions)) |
+| SLO Endpoint | `/saml/slo`                                | `/Saml2/SLO` ([configurable](/identityserver/saml/configuration.md#samlendpointoptions)) |
+| Metadata     | `/saml/metadata`                           | `/Saml2` ([configurable](/identityserver/saml/configuration.md#samlendpointoptions))     |
 
 
 ## Migration Guide
@@ -33,8 +33,7 @@ Before migrating, ensure:
 
 1. **Duende License with SAML support**: [see IdentityServer pricing page](https://duendesoftware.com/products/identityserver)
 2. **.NET 10 SDK**: Duende v8+ requires .NET 10
-3. **Backup**: Export your current SAML Service Provider (SP) configurations
-4. **Test Environment**: Set up a test environment before production migration
+3. **Test Environment**: Set up a test environment before production migration
 
 ### Step 1: Update Target Framework
 
@@ -330,7 +329,12 @@ If your RSK configuration used `HttpPost` for SLO, change it to `HttpRedirect`:
 | `/saml/slo`      | `/Saml2/SLO` |
 | `/saml/metadata` | `/Saml2`     |
 
-Update any Service Providers that have hardcoded these URLs.
+These paths are [configurable via `SamlOptions.Endpoints`](/identityserver/saml/configuration.md#samlendpointoptions). You have two options:
+
+1. **Update external Service Providers** to use the new Duende endpoint paths
+2. **Configure Duende to use the legacy RSK paths** — this is useful when you have external SPs that you don't control or cannot easily update
+
+If not all integrations are under your control, configuring IdentityServer to use the legacy paths may be the simpler approach.
 
 ### Signing Behavior Changed from Bool to Enum
 
@@ -340,11 +344,11 @@ Update any Service Providers that have hardcoded these URLs.
 + SigningBehavior = SamlSigningBehavior.SignAssertion
 ```
 
-Available values: `SignAssertion`, `SignResponse`, `SignBoth`, `DoNotSign`
+Available values: `SignAssertion`, `SignResponse`, `SignBoth`, `DoNotSign`. See [SAML Configuration](/identityserver/saml/configuration.md) for details.
 
 ### License Configuration Changed
 
-RSK SAML had its own license. Duende uses a single license key:
+RSK SAML had its own license. Duende uses a single license key. See the [licensing documentation](/general/licensing.md#license-key) for configuration options.
 
 ```diff lang="csharp" title="Program.cs"
 - .AddSamlPlugin(options =>
@@ -358,9 +362,9 @@ RSK SAML had its own license. Duende uses a single license key:
 + });
 ```
 
-### Property Naming Changes
+### Property Naming Differences
 
-Watch for subtle naming differences:
+Watch for these subtle naming differences when translating RSK code to Duende:
 
 - `ClaimsMapping` → `ClaimMappings` (plural)
 - `AllowIdpInitiatedSso` → `AllowIdpInitiated` (shorter)
@@ -383,9 +387,13 @@ After migration, verify:
 
 ### Quick Metadata Test
 
+Verify the metadata endpoint returns valid SAML metadata:
+
 ```bash title="Terminal"
 curl -k https://localhost:5001/Saml2
 ```
+
+You should receive an XML document starting with `<EntityDescriptor>` containing your IdP's entity ID, signing certificates, and endpoint locations. If you've [configured custom endpoint paths](/identityserver/saml/configuration.md#samlendpointoptions), adjust the URL accordingly.
 
 ## Troubleshooting
 
@@ -428,7 +436,7 @@ Change your ACS endpoint binding to `SamlBinding.HttpPost`. HTTP-Redirect cannot
 
 ## Related Resources
 
-- [SAML 2.0 Identity Provider Documentation](/identityserver/saml/)
+- [SAML 2.0 Identity Provider Documentation](/identityserver/saml/index.md)
 - [SAML Service Provider Configuration](/identityserver/saml/service-providers.md)
 - [SAML Endpoints Reference](/identityserver/saml/endpoints.md)
 - [v7.4 to v8.0 Upgrade Guide](/identityserver/upgrades/v7_4-to-v8_0.md)

--- a/astro/src/content/docs/identityserver/upgrades/v7_4-to-v8_0.md
+++ b/astro/src/content/docs/identityserver/upgrades/v7_4-to-v8_0.md
@@ -696,6 +696,10 @@ with enterprise applications and legacy systems that use SAML. See the
 This feature is part of the [Duende IdentityServer Standard (add-on), Advanced, and Custom Edition](https://duendesoftware.com/products/identityserver).
 :::
 
+:::tip[Migrating from Rock Solid Knowledge SAML?]
+If you were using the Rock Solid Knowledge (RSK) SAML addon (`Rsk.Saml.DuendeIdentityServer`) with IdentityServer v7.x, see the dedicated [RSK SAML Migration Guide](/identityserver/upgrades/rsk-saml-to-duende-identityserver.md) for step-by-step instructions on transitioning to built-in SAML support.
+:::
+
 ### Financial-Grade Security and Conformance Report
 
 A new `Duende.IdentityServer.ConformanceReport` package generates an HTML report assessing your


### PR DESCRIPTION
This pull request adds a comprehensive migration guide for transitioning from RSK SAML to Duende IdentityServer with built-in SAML support. Additionally, references throughout the documentation have been updated for consistency.