### PR TITLE
docs: Add IdP-initiated SSO support for SAML Service Provider

### DIFF
--- a/astro/src/content/docs/identityserver/ui/login/dynamicproviders.md
+++ b/astro/src/content/docs/identityserver/ui/login/dynamicproviders.md
@@ -248,7 +248,9 @@ SAML dynamic providers use the `SamlProvider` model, which extends `IdentityProv
 * `SigningCertificateBase64` (`string?`, default `null`) — Base64-encoded X.509 certificate for validating IdP signatures. This is singular because each dynamic provider record represents one IdP configuration. For key rollover with dynamic providers, update the record with the new certificate. In contrast, the [static SAML provider](/identityserver/ui/login/saml-provider) uses `SigningCertificatesBase64` (a list) to support multiple certificates simultaneously during rollover periods.
 * `BindingType` (`string`, default `"redirect"`) — The SAML binding type (`"redirect"` or `"post"`).
 * `SpEntityId` (`string?`, default `null`) — The entity ID of your application (the SP). When `null`, derived from the IdentityServer issuer.
-* `AllowUnsolicitedAuthnResponse` (`bool`, default `false`) — Whether to accept IdP-initiated (unsolicited) responses.
+* `AllowUnsolicitedAuthnResponse` (`bool`, default `false`) — Whether to accept IdP-initiated (unsolicited) responses. When `true`, also set `IdpInitiatedCallbackUrl`.
+* `IdpInitiatedCallbackUrl` (`string?`, default `null`) — The URL to redirect to after processing an IdP-initiated (unsolicited) response. Required when `AllowUnsolicitedAuthnResponse` is `true`. Must be a relative path or absolute URL with http/https scheme.
+* `MaxRelayStateLength` (`int`, default `1024`) — Maximum length (in bytes) of SAML RelayState to persist in authentication properties. Values exceeding this limit are not surfaced.
 * `WantAssertionsSigned` (`bool`, default `true`) — Whether assertions from the IdP must be signed.
 * `OutboundSigningAlgorithm` (`string`, default RSA-SHA256) — The XML signature algorithm for outbound requests.
 * `SpSigningCertificateBase64` (`string?`, default `null`) — Base64-encoded PKCS#12 certificate (with private key) that your SP uses to sign outbound SAML messages such as `AuthnRequest` and `LogoutResponse`. Set this when the remote IdP requires signed requests or when you use single logout.
@@ -272,6 +274,10 @@ builder.Services.AddIdentityServer()
             IdpEntityId = "https://adfs.corporate.example.com",
             SingleSignOnServiceUrl = "https://adfs.corporate.example.com/adfs/ls/",
             SigningCertificateBase64 = "<base64-encoded certificate>",
+            
+            // Optional: Enable IdP-initiated SSO
+            AllowUnsolicitedAuthnResponse = true,
+            IdpInitiatedCallbackUrl = "/ExternalLogin/Callback"
         }
     });
 ```

--- a/astro/src/content/docs/identityserver/ui/login/saml-provider.md
+++ b/astro/src/content/docs/identityserver/ui/login/saml-provider.md
@@ -83,7 +83,13 @@ The `SamlServiceProviderOptions` class controls how the SP handler communicates 
   Base64-encoded X.509 certificates used to validate signatures from the IdP. You can provide multiple certificates to support key rotation. Defaults to empty list.
 
 * **`AllowUnsolicitedAuthnResponse`**
-  Whether to allow unsolicited (IdP-initiated) authentication responses. Defaults to `false`.
+  Whether to allow unsolicited (IdP-initiated) authentication responses. When `true`, also set `IdpInitiatedCallbackUrl` to specify where users land after authentication. Defaults to `false`.
+
+* **`IdpInitiatedCallbackUrl`**
+  The URL to redirect to after processing an unsolicited (IdP-initiated) authentication response. Required when `AllowUnsolicitedAuthnResponse` is `true`. Must be a relative path (e.g., `/ExternalLogin/Callback`) or an absolute URL with http/https scheme. Defaults to `null`.
+
+* **`MaxRelayStateLength`**
+  Maximum length (in bytes) of the SAML RelayState value that will be persisted in authentication properties. RelayState values exceeding this limit are silently dropped to prevent cookie bloat. Defaults to `1024`.
 
 * **`WantAssertionsSigned`**
   Whether assertions from the IdP must be signed. Defaults to `true`.
@@ -127,3 +133,76 @@ Use this table to decide which registration approach fits your situation:
 Both approaches use the same underlying SAML SP handler. Static registration is simpler when you have a fixed set of providers and do not need runtime management.
 
 For background on the IdP and SP roles in SAML 2.0, see [IdP and SP Concepts](/identityserver/saml/idp-and-sp.mdx).
+
+## IdP-Initiated SSO
+
+In a typical SP-initiated flow, your application redirects users to the external IdP for authentication. However, some enterprise scenarios require **IdP-initiated SSO**, where the external IdP sends users directly to your application without a prior authentication request.
+
+To enable IdP-initiated SSO, set `AllowUnsolicitedAuthnResponse` to `true` and configure `IdpInitiatedCallbackUrl` to specify where users should land after authentication:
+
+```csharp
+// Program.cs
+builder.Services.AddAuthentication()
+    .AddSamlServiceProvider("corporate-idp", options =>
+    {
+        options.SpEntityId = "https://my-app.example.com";
+        options.IdpEntityId = "https://corporate-idp.example.com";
+        options.SingleSignOnServiceUrl = "https://corporate-idp.example.com/saml2/sso";
+        options.SigningCertificatesBase64 = ["<base64-encoded signing certificate>"];
+        
+        // Enable IdP-initiated SSO
+        options.AllowUnsolicitedAuthnResponse = true;
+        options.IdpInitiatedCallbackUrl = "/ExternalLogin/Callback";
+        
+        options.SignInScheme = IdentityServerConstants.ExternalCookieAuthenticationScheme;
+    });
+```
+
+### Handling the Callback
+
+In your external login callback, you can access the authentication result and read the RelayState (if provided by the IdP):
+
+```csharp
+// ExternalLoginController.cs or Callback.cshtml.cs
+public async Task<IActionResult> Callback()
+{
+    var result = await HttpContext.AuthenticateAsync(
+        IdentityServerConstants.ExternalCookieAuthenticationScheme);
+    
+    if (result?.Succeeded != true)
+    {
+        throw new Exception("External authentication failed");
+    }
+    
+    // The scheme name is available for identifying which provider was used
+    result.Properties?.Items.TryGetValue("scheme", out var scheme);
+    
+    // For IdP-initiated flows, the IdP may include RelayState for routing
+    if (result.Properties?.Items.TryGetValue("relayState", out var relayState) == true
+        && !string.IsNullOrEmpty(relayState))
+    {
+        // Use relayState for app-specific routing (e.g., deep linking to a dashboard)
+        // Note: Validate the relayState before using it for redirects
+    }
+    
+    // A default returnUrl is provided for IdP-initiated flows
+    result.Properties?.Items.TryGetValue("returnUrl", out var returnUrl);
+    
+    // Process the external login (create/update user, establish session, etc.)
+    // ...
+}
+```
+
+### RelayState Handling
+
+When the external IdP includes a RelayState value in its response, IdentityServer surfaces it in `AuthenticationProperties.Items["relayState"]`. This allows your application to:
+
+- Deep-link users to specific pages after authentication
+- Pass application-specific context through the authentication flow
+- Implement custom routing logic based on IdP-provided data
+
+RelayState values larger than `MaxRelayStateLength` (default: 1024 bytes) are not persisted to prevent cookie size issues.
+
+:::caution[Security consideration]
+Always validate RelayState values before using them for redirects. Treat RelayState as untrusted input from the IdP and ensure any URLs derived from it are safe (e.g., local to your application).
+:::


### PR DESCRIPTION
## Summary

Documents the new IdP-initiated SSO feature for SAML Service Provider authentication (when IdentityServer acts as an SP consuming assertions from an upstream IdP).

This corresponds to the latest release of IdentityServer.

## Changes

### `saml-provider.md` (Static SAML SP)
- Added `IdpInitiatedCallbackUrl` property documentation
- Added `MaxRelayStateLength` property documentation  
- Added new **IdP-Initiated SSO** section with:
  - Configuration example
  - Callback handling code showing how to read `scheme`, `relayState`, and `returnUrl` from auth properties
  - RelayState handling explanation
  - Security considerations

### `dynamicproviders.md` (Dynamic SAML Providers)
- Added `IdpInitiatedCallbackUrl` property to SamlProvider model docs
- Added `MaxRelayStateLength` property to SamlProvider model docs
- Updated example to show IdP-initiated configuration

## New Properties Documented

| Property | Type | Description |
|----------|------|-------------|
| `IdpInitiatedCallbackUrl` | `string?` | URL to redirect to after processing IdP-initiated auth response |
| `MaxRelayStateLength` | `int` | Max bytes of RelayState to persist in auth properties (default: 1024) |
