### PR TITLE
Fix misleading ISamlSigninStateSerializer tip wording

### DIFF
--- a/astro/src/content/docs/identityserver/saml/extensibility.md
+++ b/astro/src/content/docs/identityserver/saml/extensibility.md
@@ -913,7 +913,7 @@ public class CustomDistributedSamlSigninStateStore : ISamlSigninStateStore
 ```
 
 :::tip
-The example above uses `JsonSerializer` directly for simplicity. For production use, consider injecting [`ISamlSigninStateSerializer`](#isamlsigninstateserializer) instead, which provides the same serialization logic used by the built-in EF Core store and handles any custom `Extensions` content correctly.
+The example above uses `JsonSerializer` directly for simplicity. For production use, consider injecting [`ISamlSigninStateSerializer`](#isamlsigninstateserializer) instead, which provides the same serialization logic used by the built-in EF Core store. Note that the default serializer ignores the `Extensions` property — if you need to persist custom extension data, you'll need to implement a custom serializer.
 :::
 
 ---


### PR DESCRIPTION
Addresses feedback from @bhazen on PR #1157.

## Change
Corrects the tip in the SAML extensibility docs that incorrectly stated the default `ISamlSigninStateSerializer` handles `Extensions` content correctly. 

The default implementation actually **ignores** the `Extensions` property entirely. Updated the wording to accurately describe this behavior and guide users to implement a custom serializer if they need to persist extension data.

## Before
> For production use, consider injecting `ISamlSigninStateSerializer` instead, which provides the same serialization logic used by the built-in EF Core store **and handles any custom `Extensions` content correctly**.

## After
> For production use, consider injecting `ISamlSigninStateSerializer` instead, which provides the same serialization logic used by the built-in EF Core store. **Note that the default serializer ignores the `Extensions` property — if you need to persist custom extension data, you'll need to implement a custom serializer.**