### PR TITLE
Add documentation for IScopeParser and IResourceValidator

### DIFF
--- a/astro/src/content/docs/identityserver/fundamentals/resources/api-scopes.mdx
+++ b/astro/src/content/docs/identityserver/fundamentals/resources/api-scopes.mdx
@@ -124,9 +124,9 @@ claim in the `issuer_name/resources` format. If you need more control of the aud
 Sometimes scopes have a certain structure, e.g. a scope name with an additional parameter: `transaction:id` or
 `read_patient:patientid`. This pattern is useful when:
 
-- **Transaction-scoped access** — Tokens bound to a specific transaction, order, or workflow
-- **Multi-tenant systems** — Scopes that encode tenant context like `tenant:acme:read`
-- **Resource-specific permissions** — Access to a particular document, patient record, or account
+- **Transaction-scoped access** - Tokens bound to a specific transaction, order, or workflow
+- **Multi-tenant systems** - Scopes that encode tenant context like `tenant:acme:read`
+- **Resource-specific permissions** - Access to a particular document, patient record, or account
 
 In this case you would create a scope without the parameter part and assign that name to a client, but in addition
 provide some logic to parse the structure

--- a/astro/src/content/docs/identityserver/fundamentals/resources/api-scopes.mdx
+++ b/astro/src/content/docs/identityserver/fundamentals/resources/api-scopes.mdx
@@ -10,6 +10,8 @@ redirect_from:
   - /identityserver/v7/fundamentals/resources/api_scopes/
 ---
 
+import { LinkCard } from "@astrojs/starlight/components";
+
 Designing your API surface can be a complicated task. Duende IdentityServer provides a couple of primitives to help you
 with that.
 
@@ -120,11 +122,19 @@ claim in the `issuer_name/resources` format. If you need more control of the aud
 ### Parameterized Scopes
 
 Sometimes scopes have a certain structure, e.g. a scope name with an additional parameter: `transaction:id` or
-`read_patient:patientid`.
+`read_patient:patientid`. This pattern is useful when:
+
+- **Transaction-scoped access** — Tokens bound to a specific transaction, order, or workflow
+- **Multi-tenant systems** — Scopes that encode tenant context like `tenant:acme:read`
+- **Resource-specific permissions** — Access to a particular document, patient record, or account
 
 In this case you would create a scope without the parameter part and assign that name to a client, but in addition
 provide some logic to parse the structure
-of the scope at runtime using the `IScopeParser` interface or by deriving from our default implementation, e.g.:
+of the scope at runtime using the `IScopeParser` interface or by deriving from our default implementation.
+
+#### Implementing a Scope Parser
+
+Create a custom parser by extending `DefaultScopeParser`:
 
 ```csharp
 public class ParameterizedScopeParser : DefaultScopeParser
@@ -168,6 +178,15 @@ public class ParameterizedScopeParser : DefaultScopeParser
 }
 ```
 
+Register your parser in `ConfigureServices`:
+
+```csharp
+builder.Services.AddIdentityServer()
+    .AddScopeParser<ParameterizedScopeParser>();
+```
+
+#### Accessing Parsed Values
+
 You then have access to the parsed value throughout the pipeline, e.g. in the profile service:
 
 ```csharp
@@ -183,3 +202,19 @@ public class HostProfileService : IProfileService
     }
 }
 ```
+
+#### Validating Dynamic Scopes
+
+When using parameterized scopes, you may also want to customize how scopes are validated. For example, you might verify that a transaction ID exists, or that the client is authorized for a specific tenant. Use `IResourceValidator` to add this validation logic.
+
+<LinkCard
+  title="Scope Parser Reference"
+  href="/identityserver/reference/v8/parsers/scope-parser/"
+  description="Full API reference for IScopeParser with additional scenarios"
+/>
+
+<LinkCard
+  title="Resource Validator Reference"
+  href="/identityserver/reference/v8/validators/resource-validator/"
+  description="Validate parameterized scopes against external systems"
+/>

--- a/astro/src/content/docs/identityserver/reference/v7/parsers/_meta.yml
+++ b/astro/src/content/docs/identityserver/reference/v7/parsers/_meta.yml
@@ -1,0 +1,2 @@
+label: "Parsers"
+collapsed: true

--- a/astro/src/content/docs/identityserver/reference/v7/parsers/scope-parser.mdx
+++ b/astro/src/content/docs/identityserver/reference/v7/parsers/scope-parser.mdx
@@ -8,7 +8,7 @@ sidebar:
 
 import { LinkCard } from "@astrojs/starlight/components";
 
-The `IScopeParser` interface is responsible for parsing the raw `scope` parameter from OAuth/OIDC requests into individual, structured scope values. While the default implementation treats scopes as simple space-delimited strings, custom implementations enable **parameterized scopes** — scopes that carry dynamic data like transaction IDs, tenant identifiers, or resource-specific parameters.
+The `IScopeParser` interface is responsible for parsing the raw `scope` parameter from OAuth/OIDC requests into individual, structured scope values. While the default implementation treats scopes as simple space-delimited strings, custom implementations enable **parameterized scopes** - scopes that carry dynamic data like transaction IDs, tenant identifiers, or resource-specific parameters.
 
 ## When to Use
 
@@ -38,12 +38,12 @@ public interface IScopeParser
 
 Receives the scope values as a collection (already split from the space-delimited request parameter) and returns a `ParsedScopesResult` containing:
 
-- **`ParsedScopes`** — A collection of `ParsedScopeValue` objects, each with:
-  - `RawValue` — The original scope string segment
-  - `ParsedName` — The scope name (e.g., `"transaction"`)
-  - `ParsedParameter` — The extracted parameter, if any (e.g., `"123"`)
-- **`Errors`** — Any parsing errors encountered
-- **`Succeeded`** — Whether parsing completed without errors
+- **`ParsedScopes`** - A collection of `ParsedScopeValue` objects, each with:
+  - `RawValue` - The original scope string segment
+  - `ParsedName` - The scope name (e.g., `"transaction"`)
+  - `ParsedParameter` - The extracted parameter, if any (e.g., `"123"`)
+- **`Errors`** - Any parsing errors encountered
+- **`Succeeded`** - Whether parsing completed without errors
 
 ## Default Implementation
 

--- a/astro/src/content/docs/identityserver/reference/v7/parsers/scope-parser.mdx
+++ b/astro/src/content/docs/identityserver/reference/v7/parsers/scope-parser.mdx
@@ -120,7 +120,7 @@ if (txScope?.ParsedParameter != null)
 
 ### Multi-Tenant Scopes
 
-Encode tenant context in scopes like `tenant:acme:read` or `api.acme.read`:
+Encode tenant context in scopes like `tenant:acme:read`:
 
 ```csharp
 public override void ParseScopeValue(ParseScopeContext scopeContext)

--- a/astro/src/content/docs/identityserver/reference/v7/parsers/scope-parser.mdx
+++ b/astro/src/content/docs/identityserver/reference/v7/parsers/scope-parser.mdx
@@ -1,0 +1,190 @@
+---
+title: "Scope Parser"
+description: "Reference documentation for IScopeParser, which parses raw scope strings from authorization and token requests into structured ParsedScopeValue objects."
+sidebar:
+  label: Scope Parser
+  order: 10
+---
+
+import { LinkCard } from "@astrojs/starlight/components";
+
+The `IScopeParser` interface is responsible for parsing the raw `scope` parameter from OAuth/OIDC requests into individual, structured scope values. While the default implementation treats scopes as simple space-delimited strings, custom implementations enable **parameterized scopes** — scopes that carry dynamic data like transaction IDs, tenant identifiers, or resource-specific parameters.
+
+## When to Use
+
+Use a custom scope parser when:
+- Scopes carry runtime parameters (e.g., `transaction:abc123`, `tenant:acme`)
+- You need to validate scope structure before further processing
+- Scope values follow a convention that requires extraction of embedded data
+
+## Interface
+
+#### Duende.IdentityServer.Validation.IScopeParser
+
+```csharp
+/// <summary>
+/// Allows parsing raw scopes values into structured scope values.
+/// </summary>
+public interface IScopeParser
+{
+    /// <summary>
+    /// Parses the requested scopes.
+    /// </summary>
+    ParsedScopesResult ParseScopeValues(IEnumerable<string> scopeValues);
+}
+```
+
+### ParseScopeValues
+
+Receives the scope values as a collection (already split from the space-delimited request parameter) and returns a `ParsedScopesResult` containing:
+
+- **`ParsedScopes`** — A collection of `ParsedScopeValue` objects, each with:
+  - `RawValue` — The original scope string segment
+  - `ParsedName` — The scope name (e.g., `"transaction"`)
+  - `ParsedParameter` — The extracted parameter, if any (e.g., `"123"`)
+- **`Errors`** — Any parsing errors encountered
+- **`Succeeded`** — Whether parsing completed without errors
+
+## Default Implementation
+
+The `DefaultScopeParser` iterates over the scope values and creates a `ParsedScopeValue` for each. Override the virtual `ParseScopeValue` method to add custom parsing logic for parameterized scopes:
+
+```csharp
+public class ParameterizedScopeParser : DefaultScopeParser
+{
+    public ParameterizedScopeParser(ILogger<DefaultScopeParser> logger) : base(logger)
+    { }
+
+    public override void ParseScopeValue(ParseScopeContext scopeContext)
+    {
+        // Custom parsing logic here
+        // Call base.ParseScopeValue(scopeContext) for standard scopes
+    }
+}
+```
+
+### DefaultScopeParser.ParseScopeContext
+
+The `ParseScopeContext` is a nested class within `DefaultScopeParser` that provides:
+
+| Member | Description |
+|--------|-------------|
+| `RawValue` | The original scope string being parsed |
+| `ParsedName` | The parsed scope name (read after `SetParsedValues`) |
+| `ParsedParameter` | The parsed parameter value (read after `SetParsedValues`) |
+| `Error` | The error message if parsing failed |
+| `Ignore` | Whether this scope should be excluded from results |
+| `Succeeded` | `true` if not ignored and no error |
+| `SetParsedValues(name, parameter)` | Sets the parsed scope name and parameter |
+| `SetIgnore()` | Marks this scope to be excluded from results |
+| `SetError(message)` | Marks this scope as invalid with an error message |
+
+## Common Scenarios
+
+### Transaction or Resource IDs
+
+Scopes like `transaction:abc123` or `document:read:456` embed resource identifiers:
+
+```csharp
+public override void ParseScopeValue(ParseScopeContext scopeContext)
+{
+    const string prefix = "transaction:";
+    
+    if (scopeContext.RawValue.StartsWith(prefix))
+    {
+        var parameter = scopeContext.RawValue.Substring(prefix.Length);
+        if (!string.IsNullOrEmpty(parameter))
+        {
+            scopeContext.SetParsedValues("transaction", parameter);
+            return;
+        }
+        scopeContext.SetError("transaction scope requires a parameter");
+        return;
+    }
+    
+    base.ParseScopeValue(scopeContext);
+}
+```
+
+Access the parsed parameter downstream in your `IProfileService`:
+
+```csharp
+var txScope = context.RequestedResources.ParsedScopes
+    .FirstOrDefault(x => x.ParsedName == "transaction");
+
+if (txScope?.ParsedParameter != null)
+{
+    context.IssuedClaims.Add(new Claim("transaction_id", txScope.ParsedParameter));
+}
+```
+
+### Multi-Tenant Scopes
+
+Encode tenant context in scopes like `tenant:acme:read` or `api.acme.read`:
+
+```csharp
+public override void ParseScopeValue(ParseScopeContext scopeContext)
+{
+    // Pattern: tenant:{tenant_id}:{permission}
+    if (scopeContext.RawValue.StartsWith("tenant:"))
+    {
+        var parts = scopeContext.RawValue.Split(':', 3);
+        if (parts.Length == 3)
+        {
+            // Store as "tenant:{permission}" with tenant ID as parameter
+            scopeContext.SetParsedValues($"tenant:{parts[2]}", parts[1]);
+            return;
+        }
+    }
+    
+    base.ParseScopeValue(scopeContext);
+}
+```
+
+### Dynamic Scope Validation
+
+Reject malformed or unauthorized scope patterns early:
+
+```csharp
+public override void ParseScopeValue(ParseScopeContext scopeContext)
+{
+    // Reject scopes with invalid characters
+    if (scopeContext.RawValue.Contains("..") || scopeContext.RawValue.Contains("//"))
+    {
+        scopeContext.SetError("Invalid scope format");
+        return;
+    }
+    
+    // Ignore internal/debug scopes in production
+    if (scopeContext.RawValue.StartsWith("debug:"))
+    {
+        scopeContext.SetIgnore();
+        return;
+    }
+    
+    base.ParseScopeValue(scopeContext);
+}
+```
+
+## Registration
+
+Register your custom scope parser in `ConfigureServices`:
+
+```csharp
+builder.Services.AddIdentityServer()
+    .AddScopeParser<ParameterizedScopeParser>();
+```
+
+## See Also
+
+<LinkCard
+  title="API Scopes"
+  href="/identityserver/fundamentals/resources/api-scopes/"
+  description="Learn about defining and using API scopes for access control"
+/>
+
+<LinkCard
+  title="Resource Validator"
+  href="/identityserver/reference/v7/validators/resource-validator/"
+  description="Validate whether requested scopes are allowed for a client"
+/>

--- a/astro/src/content/docs/identityserver/reference/v7/validators/resource-validator.mdx
+++ b/astro/src/content/docs/identityserver/reference/v7/validators/resource-validator.mdx
@@ -1,0 +1,233 @@
+---
+title: "Resource Validator"
+description: "Reference documentation for IResourceValidator, which validates whether requested scopes and resources are valid and allowed for a given client."
+sidebar:
+  label: Resource Validator
+  order: 80
+---
+
+import { LinkCard } from "@astrojs/starlight/components";
+
+The `IResourceValidator` interface validates whether the scopes and resources requested in an authorization or token request are valid and permitted for the requesting client. The default implementation checks against your configured `ApiScope`, `ApiResource`, and `IdentityResource` definitions. Custom implementations enable dynamic validation based on external systems, tenant context, or runtime business rules.
+
+## When to Use
+
+Use a custom resource validator when:
+- Resource/scope availability varies by tenant in a multi-tenant system
+- Scope authorization depends on external services or databases
+- You need to enforce business rules beyond static client configuration
+- Scopes are created dynamically and not stored in IdentityServer configuration
+
+## Interface
+
+#### Duende.IdentityServer.Validation.IResourceValidator
+
+```csharp
+/// <summary>
+/// Validates requested resources (scopes and resource indicators)
+/// </summary>
+public interface IResourceValidator
+{
+    /// <summary>
+    /// Validates the requested resources for the client.
+    /// </summary>
+    /// <param name="request">The resource validation request.</param>
+    Task<ResourceValidationResult> ValidateRequestedResourcesAsync(
+        ResourceValidationRequest request);
+}
+```
+
+### ValidateRequestedResourcesAsync
+
+Validates the requested scopes against the client's permissions and your resource configuration. Returns a `ResourceValidationResult` containing:
+
+- **`Succeeded`** — `true` if scopes are valid and no invalid scopes/indicators
+- **`Resources`** — The validated `Resources` object with:
+  - `IdentityResources` — Matched identity resources (e.g., `openid`, `profile`)
+  - `ApiResources` — Matched API resources
+  - `ApiScopes` — Matched API scopes
+  - `OfflineAccess` — Whether `offline_access` was requested
+- **`ParsedScopes`** — The `ParsedScopeValue` objects from the scope parser
+- **`RawScopeValues`** — The original scope strings
+- **`InvalidScopes`** — Scopes that failed validation
+- **`InvalidResourceIndicators`** — Resource indicators that failed validation
+
+### ResourceValidationRequest
+
+The request object provides:
+
+| Member | Description |
+|--------|-------------|
+| `Client` | The requesting client |
+| `Scopes` | The raw scope values (`IEnumerable<string>`) |
+| `ResourceIndicators` | Resource indicators from the request (RFC 8707) |
+
+## Default Behavior
+
+The `DefaultResourceValidator`:
+1. Looks up each parsed scope in configured `IdentityResources`, `ApiScopes`, and checks for `offline_access`
+2. Verifies the client is allowed to request each scope via `Client.AllowedScopes`
+3. Resolves `ApiResources` associated with the requested `ApiScopes`
+4. Returns invalid scopes that don't match configuration or aren't allowed for the client
+
+## Common Scenarios
+
+### Multi-Tenant Resource Validation
+
+Validate scopes against tenant-specific configuration:
+
+```csharp
+public class TenantResourceValidator : IResourceValidator
+{
+    private readonly IResourceValidator _inner;
+    private readonly ITenantService _tenantService;
+    
+    public TenantResourceValidator(
+        DefaultResourceValidator inner,
+        ITenantService tenantService)
+    {
+        _inner = inner;
+        _tenantService = tenantService;
+    }
+    
+    public async Task<ResourceValidationResult> ValidateRequestedResourcesAsync(
+        ResourceValidationRequest request)
+    {
+        // First, run default validation
+        var result = await _inner.ValidateRequestedResourcesAsync(request);
+        
+        // Then apply tenant-specific restrictions
+        var tenantId = GetTenantFromClient(request.Client);
+        var tenantScopes = await _tenantService.GetAllowedScopesAsync(tenantId);
+        
+        // Filter to only tenant-allowed scopes
+        var disallowed = result.Resources.ApiScopes
+            .Where(s => !tenantScopes.Contains(s.Name))
+            .Select(s => s.Name)
+            .ToList();
+        
+        foreach (var scope in disallowed)
+        {
+            result.InvalidScopes.Add(scope);
+            result.Resources.ApiScopes.Remove(
+                result.Resources.ApiScopes.First(s => s.Name == scope));
+        }
+        
+        return result;
+    }
+}
+```
+
+### Dynamic Scope Authorization
+
+Validate parameterized scopes against external authorization:
+
+```csharp
+public class DynamicResourceValidator : IResourceValidator
+{
+    private readonly DefaultResourceValidator _inner;
+    private readonly IAuthorizationService _authz;
+    
+    public DynamicResourceValidator(
+        DefaultResourceValidator inner,
+        IAuthorizationService authz)
+    {
+        _inner = inner;
+        _authz = authz;
+    }
+    
+    public async Task<ResourceValidationResult> ValidateRequestedResourcesAsync(
+        ResourceValidationRequest request)
+    {
+        var result = await _inner.ValidateRequestedResourcesAsync(request);
+        
+        // Validate parameterized scopes against external authorization
+        foreach (var scope in result.ParsedScopes.Where(s => s.ParsedParameter != null))
+        {
+            var allowed = await _authz.IsClientAuthorizedForResourceAsync(
+                request.Client.ClientId,
+                scope.ParsedName,
+                scope.ParsedParameter);
+            
+            if (!allowed)
+            {
+                result.InvalidScopes.Add(scope.RawValue);
+            }
+        }
+        
+        return result;
+    }
+}
+```
+
+### Transaction-Scoped Validation
+
+Validate that transaction IDs exist and are accessible:
+
+```csharp
+public class TransactionResourceValidator : IResourceValidator
+{
+    private readonly DefaultResourceValidator _inner;
+    private readonly ITransactionRepository _transactions;
+    
+    public TransactionResourceValidator(
+        DefaultResourceValidator inner,
+        ITransactionRepository transactions)
+    {
+        _inner = inner;
+        _transactions = transactions;
+    }
+    
+    public async Task<ResourceValidationResult> ValidateRequestedResourcesAsync(
+        ResourceValidationRequest request)
+    {
+        var result = await _inner.ValidateRequestedResourcesAsync(request);
+        
+        // Validate transaction scope parameters
+        var txScopes = result.ParsedScopes
+            .Where(s => s.ParsedName == "transaction" && s.ParsedParameter != null);
+        
+        foreach (var scope in txScopes)
+        {
+            var exists = await _transactions.ExistsAsync(scope.ParsedParameter);
+            if (!exists)
+            {
+                result.InvalidScopes.Add(scope.RawValue);
+            }
+        }
+        
+        return result;
+    }
+}
+```
+
+## Registration
+
+Register your custom resource validator in `ConfigureServices`:
+
+```csharp
+builder.Services.AddIdentityServer()
+    .AddResourceValidator<TenantResourceValidator>();
+```
+
+When decorating the default validator, register it explicitly:
+
+```csharp
+builder.Services.AddTransient<DefaultResourceValidator>();
+builder.Services.AddIdentityServer()
+    .AddResourceValidator<TenantResourceValidator>();
+```
+
+## See Also
+
+<LinkCard
+  title="Scope Parser"
+  href="/identityserver/reference/v7/parsers/scope-parser/"
+  description="Parse parameterized scopes before validation"
+/>
+
+<LinkCard
+  title="API Scopes"
+  href="/identityserver/fundamentals/resources/api-scopes/"
+  description="Define and configure API scopes"
+/>

--- a/astro/src/content/docs/identityserver/reference/v7/validators/resource-validator.mdx
+++ b/astro/src/content/docs/identityserver/reference/v7/validators/resource-validator.mdx
@@ -41,16 +41,16 @@ public interface IResourceValidator
 
 Validates the requested scopes against the client's permissions and your resource configuration. Returns a `ResourceValidationResult` containing:
 
-- **`Succeeded`** — `true` if scopes are valid and no invalid scopes/indicators
-- **`Resources`** — The validated `Resources` object with:
-  - `IdentityResources` — Matched identity resources (e.g., `openid`, `profile`)
-  - `ApiResources` — Matched API resources
-  - `ApiScopes` — Matched API scopes
-  - `OfflineAccess` — Whether `offline_access` was requested
-- **`ParsedScopes`** — The `ParsedScopeValue` objects from the scope parser
-- **`RawScopeValues`** — The original scope strings
-- **`InvalidScopes`** — Scopes that failed validation
-- **`InvalidResourceIndicators`** — Resource indicators that failed validation
+- **`Succeeded`** - `true` if scopes are valid and no invalid scopes/indicators
+- **`Resources`** - The validated `Resources` object with:
+  - `IdentityResources` - Matched identity resources (e.g., `openid`, `profile`)
+  - `ApiResources` - Matched API resources
+  - `ApiScopes` - Matched API scopes
+  - `OfflineAccess` - Whether `offline_access` was requested
+- **`ParsedScopes`** - The `ParsedScopeValue` objects from the scope parser
+- **`RawScopeValues`** - The original scope strings
+- **`InvalidScopes`** - Scopes that failed validation
+- **`InvalidResourceIndicators`** - Resource indicators that failed validation
 
 ### ResourceValidationRequest
 

--- a/astro/src/content/docs/identityserver/reference/v8/parsers/_meta.yml
+++ b/astro/src/content/docs/identityserver/reference/v8/parsers/_meta.yml
@@ -1,0 +1,2 @@
+label: "Parsers"
+collapsed: true

--- a/astro/src/content/docs/identityserver/reference/v8/parsers/scope-parser.mdx
+++ b/astro/src/content/docs/identityserver/reference/v8/parsers/scope-parser.mdx
@@ -1,0 +1,190 @@
+---
+title: "Scope Parser"
+description: "Reference documentation for IScopeParser, which parses raw scope strings from authorization and token requests into structured ParsedScopeValue objects."
+sidebar:
+  label: Scope Parser
+  order: 10
+---
+
+import { LinkCard } from "@astrojs/starlight/components";
+
+The `IScopeParser` interface is responsible for parsing the raw `scope` parameter from OAuth/OIDC requests into individual, structured scope values. While the default implementation treats scopes as simple space-delimited strings, custom implementations enable **parameterized scopes** — scopes that carry dynamic data like transaction IDs, tenant identifiers, or resource-specific parameters.
+
+## When to Use
+
+Use a custom scope parser when:
+- Scopes carry runtime parameters (e.g., `transaction:abc123`, `tenant:acme`)
+- You need to validate scope structure before further processing
+- Scope values follow a convention that requires extraction of embedded data
+
+## Interface
+
+#### Duende.IdentityServer.Validation.IScopeParser
+
+```csharp
+/// <summary>
+/// Allows parsing raw scopes values into structured scope values.
+/// </summary>
+public interface IScopeParser
+{
+    /// <summary>
+    /// Parses the requested scopes.
+    /// </summary>
+    ParsedScopesResult ParseScopeValues(IEnumerable<string> scopeValues);
+}
+```
+
+### ParseScopeValues
+
+Receives the scope values as a collection (already split from the space-delimited request parameter) and returns a `ParsedScopesResult` containing:
+
+- **`ParsedScopes`** — A collection of `ParsedScopeValue` objects, each with:
+  - `RawValue` — The original scope string segment
+  - `ParsedName` — The scope name (e.g., `"transaction"`)
+  - `ParsedParameter` — The extracted parameter, if any (e.g., `"123"`)
+- **`Errors`** — Any parsing errors encountered
+- **`Succeeded`** — Whether parsing completed without errors
+
+## Default Implementation
+
+The `DefaultScopeParser` iterates over the scope values and creates a `ParsedScopeValue` for each. Override the virtual `ParseScopeValue` method to add custom parsing logic for parameterized scopes:
+
+```csharp
+public class ParameterizedScopeParser : DefaultScopeParser
+{
+    public ParameterizedScopeParser(ILogger<DefaultScopeParser> logger) : base(logger)
+    { }
+
+    public override void ParseScopeValue(ParseScopeContext scopeContext)
+    {
+        // Custom parsing logic here
+        // Call base.ParseScopeValue(scopeContext) for standard scopes
+    }
+}
+```
+
+### DefaultScopeParser.ParseScopeContext
+
+The `ParseScopeContext` is a nested class within `DefaultScopeParser` that provides:
+
+| Member | Description |
+|--------|-------------|
+| `RawValue` | The original scope string being parsed |
+| `ParsedName` | The parsed scope name (read after `SetParsedValues`) |
+| `ParsedParameter` | The parsed parameter value (read after `SetParsedValues`) |
+| `Error` | The error message if parsing failed |
+| `Ignore` | Whether this scope should be excluded from results |
+| `Succeeded` | `true` if not ignored and no error |
+| `SetParsedValues(name, parameter)` | Sets the parsed scope name and parameter |
+| `SetIgnore()` | Marks this scope to be excluded from results |
+| `SetError(message)` | Marks this scope as invalid with an error message |
+
+## Common Scenarios
+
+### Transaction or Resource IDs
+
+Scopes like `transaction:abc123` or `document:read:456` embed resource identifiers:
+
+```csharp
+public override void ParseScopeValue(ParseScopeContext scopeContext)
+{
+    const string prefix = "transaction:";
+    
+    if (scopeContext.RawValue.StartsWith(prefix))
+    {
+        var parameter = scopeContext.RawValue.Substring(prefix.Length);
+        if (!string.IsNullOrEmpty(parameter))
+        {
+            scopeContext.SetParsedValues("transaction", parameter);
+            return;
+        }
+        scopeContext.SetError("transaction scope requires a parameter");
+        return;
+    }
+    
+    base.ParseScopeValue(scopeContext);
+}
+```
+
+Access the parsed parameter downstream in your `IProfileService`:
+
+```csharp
+var txScope = context.RequestedResources.ParsedScopes
+    .FirstOrDefault(x => x.ParsedName == "transaction");
+
+if (txScope?.ParsedParameter != null)
+{
+    context.IssuedClaims.Add(new Claim("transaction_id", txScope.ParsedParameter));
+}
+```
+
+### Multi-Tenant Scopes
+
+Encode tenant context in scopes like `tenant:acme:read` or `api.acme.read`:
+
+```csharp
+public override void ParseScopeValue(ParseScopeContext scopeContext)
+{
+    // Pattern: tenant:{tenant_id}:{permission}
+    if (scopeContext.RawValue.StartsWith("tenant:"))
+    {
+        var parts = scopeContext.RawValue.Split(':', 3);
+        if (parts.Length == 3)
+        {
+            // Store as "tenant:{permission}" with tenant ID as parameter
+            scopeContext.SetParsedValues($"tenant:{parts[2]}", parts[1]);
+            return;
+        }
+    }
+    
+    base.ParseScopeValue(scopeContext);
+}
+```
+
+### Dynamic Scope Validation
+
+Reject malformed or unauthorized scope patterns early:
+
+```csharp
+public override void ParseScopeValue(ParseScopeContext scopeContext)
+{
+    // Reject scopes with invalid characters
+    if (scopeContext.RawValue.Contains("..") || scopeContext.RawValue.Contains("//"))
+    {
+        scopeContext.SetError("Invalid scope format");
+        return;
+    }
+    
+    // Ignore internal/debug scopes in production
+    if (scopeContext.RawValue.StartsWith("debug:"))
+    {
+        scopeContext.SetIgnore();
+        return;
+    }
+    
+    base.ParseScopeValue(scopeContext);
+}
+```
+
+## Registration
+
+Register your custom scope parser in `ConfigureServices`:
+
+```csharp
+builder.Services.AddIdentityServer()
+    .AddScopeParser<ParameterizedScopeParser>();
+```
+
+## See Also
+
+<LinkCard
+  title="API Scopes"
+  href="/identityserver/fundamentals/resources/api-scopes/"
+  description="Learn about defining and using API scopes for access control"
+/>
+
+<LinkCard
+  title="Resource Validator"
+  href="/identityserver/reference/v8/validators/resource-validator/"
+  description="Validate whether requested scopes are allowed for a client"
+/>

--- a/astro/src/content/docs/identityserver/reference/v8/parsers/scope-parser.mdx
+++ b/astro/src/content/docs/identityserver/reference/v8/parsers/scope-parser.mdx
@@ -8,7 +8,7 @@ sidebar:
 
 import { LinkCard } from "@astrojs/starlight/components";
 
-The `IScopeParser` interface is responsible for parsing the raw `scope` parameter from OAuth/OIDC requests into individual, structured scope values. While the default implementation treats scopes as simple space-delimited strings, custom implementations enable **parameterized scopes** — scopes that carry dynamic data like transaction IDs, tenant identifiers, or resource-specific parameters.
+The `IScopeParser` interface is responsible for parsing the raw `scope` parameter from OAuth/OIDC requests into individual, structured scope values. While the default implementation treats scopes as simple space-delimited strings, custom implementations enable **parameterized scopes** - scopes that carry dynamic data like transaction IDs, tenant identifiers, or resource-specific parameters.
 
 ## When to Use
 
@@ -38,12 +38,12 @@ public interface IScopeParser
 
 Receives the scope values as a collection (already split from the space-delimited request parameter) and returns a `ParsedScopesResult` containing:
 
-- **`ParsedScopes`** — A collection of `ParsedScopeValue` objects, each with:
-  - `RawValue` — The original scope string segment
-  - `ParsedName` — The scope name (e.g., `"transaction"`)
-  - `ParsedParameter` — The extracted parameter, if any (e.g., `"123"`)
-- **`Errors`** — Any parsing errors encountered
-- **`Succeeded`** — Whether parsing completed without errors
+- **`ParsedScopes`** - A collection of `ParsedScopeValue` objects, each with:
+  - `RawValue` - The original scope string segment
+  - `ParsedName` - The scope name (e.g., `"transaction"`)
+  - `ParsedParameter` - The extracted parameter, if any (e.g., `"123"`)
+- **`Errors`** - Any parsing errors encountered
+- **`Succeeded`** - Whether parsing completed without errors
 
 ## Default Implementation
 

--- a/astro/src/content/docs/identityserver/reference/v8/parsers/scope-parser.mdx
+++ b/astro/src/content/docs/identityserver/reference/v8/parsers/scope-parser.mdx
@@ -83,7 +83,7 @@ The `ParseScopeContext` is a nested class within `DefaultScopeParser` that provi
 
 ### Transaction or Resource IDs
 
-Scopes like `transaction:abc123` or `document:read:456` embed resource identifiers:
+Scopes like `transaction:abc123` embed resource identifiers (adapt this pattern for other conventions such as `document:read:456`):
 
 ```csharp
 public override void ParseScopeValue(ParseScopeContext scopeContext)

--- a/astro/src/content/docs/identityserver/reference/v8/validators/resource-validator.mdx
+++ b/astro/src/content/docs/identityserver/reference/v8/validators/resource-validator.mdx
@@ -1,0 +1,239 @@
+---
+title: "Resource Validator"
+description: "Reference documentation for IResourceValidator, which validates whether requested scopes and resources are valid and allowed for a given client."
+sidebar:
+  label: Resource Validator
+  order: 80
+---
+
+import { LinkCard } from "@astrojs/starlight/components";
+
+The `IResourceValidator` interface validates whether the scopes and resources requested in an authorization or token request are valid and permitted for the requesting client. The default implementation checks against your configured `ApiScope`, `ApiResource`, and `IdentityResource` definitions. Custom implementations enable dynamic validation based on external systems, tenant context, or runtime business rules.
+
+## When to Use
+
+Use a custom resource validator when:
+- Resource/scope availability varies by tenant in a multi-tenant system
+- Scope authorization depends on external services or databases
+- You need to enforce business rules beyond static client configuration
+- Scopes are created dynamically and not stored in IdentityServer configuration
+
+## Interface
+
+#### Duende.IdentityServer.Validation.IResourceValidator
+
+```csharp
+/// <summary>
+/// Validates requested resources (scopes and resource indicators)
+/// </summary>
+public interface IResourceValidator
+{
+    /// <summary>
+    /// Validates the requested resources for the client.
+    /// </summary>
+    /// <param name="request">The resource validation request.</param>
+    /// <param name="ct">The cancellation token.</param>
+    Task<ResourceValidationResult> ValidateRequestedResourcesAsync(
+        ResourceValidationRequest request, 
+        CancellationToken ct);
+}
+```
+
+### ValidateRequestedResourcesAsync
+
+Validates the requested scopes against the client's permissions and your resource configuration. Returns a `ResourceValidationResult` containing:
+
+- **`Succeeded`** — `true` if scopes are valid and no invalid scopes/indicators
+- **`Resources`** — The validated `Resources` object with:
+  - `IdentityResources` — Matched identity resources (e.g., `openid`, `profile`)
+  - `ApiResources` — Matched API resources
+  - `ApiScopes` — Matched API scopes
+  - `OfflineAccess` — Whether `offline_access` was requested
+- **`ParsedScopes`** — The `ParsedScopeValue` objects from the scope parser
+- **`RawScopeValues`** — The original scope strings
+- **`InvalidScopes`** — Scopes that failed validation
+- **`InvalidResourceIndicators`** — Resource indicators that failed validation
+
+### ResourceValidationRequest
+
+The request object provides:
+
+| Member | Description |
+|--------|-------------|
+| `Client` | The requesting client |
+| `Scopes` | The raw scope values (`IEnumerable<string>`) |
+| `ResourceIndicators` | Resource indicators from the request (RFC 8707) |
+
+## Default Behavior
+
+The `DefaultResourceValidator`:
+1. Looks up each parsed scope in configured `IdentityResources`, `ApiScopes`, and checks for `offline_access`
+2. Verifies the client is allowed to request each scope via `Client.AllowedScopes`
+3. Resolves `ApiResources` associated with the requested `ApiScopes`
+4. Returns invalid scopes that don't match configuration or aren't allowed for the client
+
+## Common Scenarios
+
+### Multi-Tenant Resource Validation
+
+Validate scopes against tenant-specific configuration:
+
+```csharp
+public class TenantResourceValidator : IResourceValidator
+{
+    private readonly IResourceValidator _inner;
+    private readonly ITenantService _tenantService;
+    
+    public TenantResourceValidator(
+        DefaultResourceValidator inner,
+        ITenantService tenantService)
+    {
+        _inner = inner;
+        _tenantService = tenantService;
+    }
+    
+    public async Task<ResourceValidationResult> ValidateRequestedResourcesAsync(
+        ResourceValidationRequest request,
+        CancellationToken ct)
+    {
+        // First, run default validation
+        var result = await _inner.ValidateRequestedResourcesAsync(request, ct);
+        
+        // Then apply tenant-specific restrictions
+        var tenantId = GetTenantFromClient(request.Client);
+        var tenantScopes = await _tenantService.GetAllowedScopesAsync(tenantId, ct);
+        
+        // Filter to only tenant-allowed scopes
+        var disallowed = result.Resources.ApiScopes
+            .Where(s => !tenantScopes.Contains(s.Name))
+            .Select(s => s.Name)
+            .ToList();
+        
+        foreach (var scope in disallowed)
+        {
+            result.InvalidScopes.Add(scope);
+            result.Resources.ApiScopes.Remove(
+                result.Resources.ApiScopes.First(s => s.Name == scope));
+        }
+        
+        return result;
+    }
+}
+```
+
+### Dynamic Scope Authorization
+
+Validate parameterized scopes against external authorization:
+
+```csharp
+public class DynamicResourceValidator : IResourceValidator
+{
+    private readonly DefaultResourceValidator _inner;
+    private readonly IAuthorizationService _authz;
+    
+    public DynamicResourceValidator(
+        DefaultResourceValidator inner,
+        IAuthorizationService authz)
+    {
+        _inner = inner;
+        _authz = authz;
+    }
+    
+    public async Task<ResourceValidationResult> ValidateRequestedResourcesAsync(
+        ResourceValidationRequest request,
+        CancellationToken ct)
+    {
+        var result = await _inner.ValidateRequestedResourcesAsync(request, ct);
+        
+        // Validate parameterized scopes against external authorization
+        foreach (var scope in result.ParsedScopes.Where(s => s.ParsedParameter != null))
+        {
+            var allowed = await _authz.IsClientAuthorizedForResourceAsync(
+                request.Client.ClientId,
+                scope.ParsedName,
+                scope.ParsedParameter,
+                ct);
+            
+            if (!allowed)
+            {
+                result.InvalidScopes.Add(scope.RawValue);
+            }
+        }
+        
+        return result;
+    }
+}
+```
+
+### Transaction-Scoped Validation
+
+Validate that transaction IDs exist and are accessible:
+
+```csharp
+public class TransactionResourceValidator : IResourceValidator
+{
+    private readonly DefaultResourceValidator _inner;
+    private readonly ITransactionRepository _transactions;
+    
+    public TransactionResourceValidator(
+        DefaultResourceValidator inner,
+        ITransactionRepository transactions)
+    {
+        _inner = inner;
+        _transactions = transactions;
+    }
+    
+    public async Task<ResourceValidationResult> ValidateRequestedResourcesAsync(
+        ResourceValidationRequest request,
+        CancellationToken ct)
+    {
+        var result = await _inner.ValidateRequestedResourcesAsync(request, ct);
+        
+        // Validate transaction scope parameters
+        var txScopes = result.ParsedScopes
+            .Where(s => s.ParsedName == "transaction" && s.ParsedParameter != null);
+        
+        foreach (var scope in txScopes)
+        {
+            var exists = await _transactions.ExistsAsync(scope.ParsedParameter, ct);
+            if (!exists)
+            {
+                result.InvalidScopes.Add(scope.RawValue);
+            }
+        }
+        
+        return result;
+    }
+}
+```
+
+## Registration
+
+Register your custom resource validator in `ConfigureServices`:
+
+```csharp
+builder.Services.AddIdentityServer()
+    .AddResourceValidator<TenantResourceValidator>();
+```
+
+When decorating the default validator, register it explicitly:
+
+```csharp
+builder.Services.AddTransient<DefaultResourceValidator>();
+builder.Services.AddIdentityServer()
+    .AddResourceValidator<TenantResourceValidator>();
+```
+
+## See Also
+
+<LinkCard
+  title="Scope Parser"
+  href="/identityserver/reference/v8/parsers/scope-parser/"
+  description="Parse parameterized scopes before validation"
+/>
+
+<LinkCard
+  title="API Scopes"
+  href="/identityserver/fundamentals/resources/api-scopes/"
+  description="Define and configure API scopes"
+/>

--- a/astro/src/content/docs/identityserver/reference/v8/validators/resource-validator.mdx
+++ b/astro/src/content/docs/identityserver/reference/v8/validators/resource-validator.mdx
@@ -43,16 +43,16 @@ public interface IResourceValidator
 
 Validates the requested scopes against the client's permissions and your resource configuration. Returns a `ResourceValidationResult` containing:
 
-- **`Succeeded`** — `true` if scopes are valid and no invalid scopes/indicators
-- **`Resources`** — The validated `Resources` object with:
-  - `IdentityResources` — Matched identity resources (e.g., `openid`, `profile`)
-  - `ApiResources` — Matched API resources
-  - `ApiScopes` — Matched API scopes
-  - `OfflineAccess` — Whether `offline_access` was requested
-- **`ParsedScopes`** — The `ParsedScopeValue` objects from the scope parser
-- **`RawScopeValues`** — The original scope strings
-- **`InvalidScopes`** — Scopes that failed validation
-- **`InvalidResourceIndicators`** — Resource indicators that failed validation
+- **`Succeeded`** - `true` if scopes are valid and no invalid scopes/indicators
+- **`Resources`** - The validated `Resources` object with:
+  - `IdentityResources` - Matched identity resources (e.g., `openid`, `profile`)
+  - `ApiResources` - Matched API resources
+  - `ApiScopes` - Matched API scopes
+  - `OfflineAccess` - Whether `offline_access` was requested
+- **`ParsedScopes`** - The `ParsedScopeValue` objects from the scope parser
+- **`RawScopeValues`** - The original scope strings
+- **`InvalidScopes`** - Scopes that failed validation
+- **`InvalidResourceIndicators`** - Resource indicators that failed validation
 
 ### ResourceValidationRequest
 


### PR DESCRIPTION
## Summary

Adds reference documentation for two extensibility interfaces that were missing from the docs:

- **IScopeParser** — Parses raw scope strings into structured `ParsedScopeValue` objects, enabling parameterized scopes like `transaction:abc123` or `tenant:acme:read`
- **IResourceValidator** — Validates whether requested scopes/resources are allowed for a client, enabling dynamic validation against external systems

## Changes

### New Files
- `reference/v7/parsers/_meta.yml` + `scope-parser.mdx`
- `reference/v8/parsers/_meta.yml` + `scope-parser.mdx`
- `reference/v7/validators/resource-validator.mdx`
- `reference/v8/validators/resource-validator.mdx`

### Modified Files
- `fundamentals/resources/api-scopes.mdx` — Expanded parameterized scopes section with scenarios and LinkCard cross-references

## Version Differences

The v8 `IResourceValidator` includes a `CancellationToken` parameter that was added in v8:

```csharp
// v7
Task<ResourceValidationResult> ValidateRequestedResourcesAsync(ResourceValidationRequest request);

// v8
Task<ResourceValidationResult> ValidateRequestedResourcesAsync(ResourceValidationRequest request, CancellationToken ct);
```

## Common Scenarios Documented
- Transaction/resource IDs (`transaction:abc123`)
- Multi-tenant scopes (`tenant:acme:read`)
- Dynamic scope validation

Closes #317