### PR TITLE
Add Multi-Issuer docs page

### DIFF
--- a/astro/src/content/docs/identityserver/index.mdx
+++ b/astro/src/content/docs/identityserver/index.mdx
@@ -51,7 +51,7 @@ Duende IdentityServer is a highly extensible, standards-compliant framework for 
     description="Configure external identity providers from a store at runtime without recompilation."
   />
   <LinkCard
-    href="/identityserver/tokens/issuer#duende-identityserver-multi-issuer"
+    href="/identityserver/tokens/issuer/#multi-issuer"
     title="Multi-Issuer"
     description="Run a single IdentityServer instance with multiple issuer identities."
   />

--- a/astro/src/content/docs/identityserver/index.mdx
+++ b/astro/src/content/docs/identityserver/index.mdx
@@ -51,7 +51,7 @@ Duende IdentityServer is a highly extensible, standards-compliant framework for 
     description="Configure external identity providers from a store at runtime without recompilation."
   />
   <LinkCard
-    href="/identityserver/reference/v8/options/"
+    href="/identityserver/tokens/issuer#duende-identityserver-multi-issuer"
     title="Multi-Issuer"
     description="Run a single IdentityServer instance with multiple issuer identities."
   />

--- a/astro/src/content/docs/identityserver/tokens/fapi-2-0-specification.md
+++ b/astro/src/content/docs/identityserver/tokens/fapi-2-0-specification.md
@@ -3,6 +3,7 @@ title: FAPI 2.0
 description: Overview of the FAPI 2.0 implementation in Duende IdentityServer 7.3+
 sidebar:
   label: FAPI 2.0
+  order: 220
   badge:
     text: v7.3
     variant: tip

--- a/astro/src/content/docs/identityserver/tokens/issuer.mdx
+++ b/astro/src/content/docs/identityserver/tokens/issuer.mdx
@@ -14,7 +14,7 @@ IdentityServer inserts the `iss` claim value using the origin IdentityServer is 
 
 ## Multi-Issuer
 
-The IdentityServer Multi-Issuer feature allows a single IdentityServer to respond with different `iss` claim values depending on the domains it hosts.
+Duende IdentityServer can respond with different `iss` claim values depending on the domains it hosts.
 
 Imagine a single IdentityServer instance is hosted over 3 different domains like `auth.dailyreader.example`, `auth.streamwave.example`, and `auth.podvault.example`. If that instance of IdentityServer was developed to allow users to sign-in across all three domains with the same credentials, the result token still only works for the APIs accepting tokens from the target issuer. For example, if the backend API only allows tokens with the issuer `auth.dailyreader.example`, a user's token with `iss` claim `auth.streamwave.example` will not be accepted. Even though their credentials work across all three domains, the token is limited to the one issuer.
 

--- a/astro/src/content/docs/identityserver/tokens/issuer.mdx
+++ b/astro/src/content/docs/identityserver/tokens/issuer.mdx
@@ -10,7 +10,7 @@ sidebar:
 
 JWT [RFC7519](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1) defines the Issuer Claim `iss`, which identifies the principal that issued the JWT. The claim holds the unique identifier for the Authorization Server. When a service receives a JWT, it should verify that the JWT came from the expected Authorization Server. It does so using the `iss` claim.
 
-IdentityServer inserts the `iss` claim value using the origin IdentityServer is hosted from. If [mTLS](/identityserver/tokens/mtls-setup.mdx) is configured with a valid domain name, part of that domain will also be included. You can choose to override this dynamic behavior by setting a static value for the `IssuerUri` property in [IdentityServer Options](/identityserver/reference/v8/options).
+IdentityServer inserts the `iss` claim value using the origin IdentityServer is hosted from by default. You can change this behavior by setting the `IssuerUri` property in [IdentityServer Options](/identityserver/reference/v8/options).
 
 ## Multi-Issuer
 

--- a/astro/src/content/docs/identityserver/tokens/issuer.mdx
+++ b/astro/src/content/docs/identityserver/tokens/issuer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Issuer"
+title: "Issuer Claim"
 description: "Overview of the issuer claim in a JWT and how IdentityServer can serve different iss claims."
 date: 2026-08-03T08:22:12+02:00
 sidebar:
@@ -8,20 +8,18 @@ sidebar:
 
 ## Issuer Claim
 
-JWT [RFC7519](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1) defines the Issuer Claim `iss`, which identifies the principal that issued the JWT. The claim holds the unique identifier for the Authorization Server. When a service receives a JWT, it should verify that the JWT came from the expected Authorization Server, and it does so using the `iss` claim.
+JWT [RFC7519](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1) defines the Issuer Claim `iss`, which identifies the principal that issued the JWT. The claim holds the unique identifier for the Authorization Server. When a service receives a JWT, it should verify that the JWT came from the expected Authorization Server. It does so using the `iss` claim.
 
-IdentityServer inserts the `iss` claim value using the origin IdentityServer is hosted from. If [mTLS](/identityserver/tokens/mtls-setup.mdx) is configured with a valid domain name, that domain name will also be included in the output `iss` claim. You can choose to override this dynamic behavior by setting a static value for the `IssuerUri` property in [IdentityServer Options](/identityserver/reference/v8/options).
+IdentityServer inserts the `iss` claim value using the origin IdentityServer is hosted from. If [mTLS](/identityserver/tokens/mtls-setup.mdx) is configured with a valid domain name, part of that domain will also be included. You can choose to override this dynamic behavior by setting a static value for the `IssuerUri` property in [IdentityServer Options](/identityserver/reference/v8/options).
 
-## Duende IdentityServer Multi-Issuer
+## Multi-Issuer
 
-<span data-shb-badge data-shb-badge-variant="default">Added in 8.0</span>
+The IdentityServer Multi-Issuer feature allows a single IdentityServer to respond with different `iss` claim values depending on the domains it hosts.
 
-The Multi-Issuer feature allows a single IdentityServer to respond with different `iss` claim values depending on the host that issued the request. 
-
-Imagine the IdentityServer instance is hosted over 3 different domains like `auth.dailyreader.example`, `auth.streamwave.example`, and `auth.podvault.example`. Users will be able to sign-in across all three domains with the same credentials, but the result token only works for the APIs accepting tokens from the target issuer. For example, if the backend API only allows tokens with the issuer `auth.dailyreader.example`, a user will not be able to use their token from `auth.streamwave.example` against it. Even though their credentials work across all three domains, the token is limited to the one issuer.
+Imagine a single IdentityServer instance is hosted over 3 different domains like `auth.dailyreader.example`, `auth.streamwave.example`, and `auth.podvault.example`. If that instance of IdentityServer was developed to allow users to sign-in across all three domains with the same credentials, the result token still only works for the APIs accepting tokens from the target issuer. For example, if the backend API only allows tokens with the issuer `auth.dailyreader.example`, a user's token with `iss` claim `auth.streamwave.example` will not be accepted. Even though their credentials work across all three domains, the token is limited to the one issuer.
 
 If you set a static value for the `IssuerUri` property in [IdentityServer Options](/identityserver/reference/v8/options), the Multi-Issuer feature will not be enabled because the returned `iss` claim will always be the value you set.
 
 :::caution
-Multi-Issuer does not mean IdentityServer can self-host itself across different domains to separate data across different tenants.
+Multi-Issuer does not mean IdentityServer can self-host itself across different domains to separate data across different tenants. You must setup that infrastructure yourself.
 :::

--- a/astro/src/content/docs/identityserver/tokens/issuer.mdx
+++ b/astro/src/content/docs/identityserver/tokens/issuer.mdx
@@ -1,0 +1,27 @@
+---
+title: "Issuer"
+description: "Overview of the issuer claim in a JWT and how IdentityServer can serve different iss claims."
+date: 2026-08-03T08:22:12+02:00
+sidebar:
+  order: 210
+---
+
+## Issuer Claim
+
+JWT [RFC7519](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1) defines the Issuer Claim `iss`, which identifies the principal that issued the JWT. The claim holds the unique identifier for the Authorization Server. When a service receives a JWT, it should verify that the JWT came from the expected Authorization Server, and it does so using the `iss` claim.
+
+IdentityServer inserts the `iss` claim value using the origin IdentityServer is hosted from. If [mTLS](/identityserver/tokens/mtls-setup.mdx) is configured with a valid domain name, that domain name will also be included in the output `iss` claim. You can choose to override this dynamic behavior by setting a static value for the `IssuerUri` property in [IdentityServer Options](/identityserver/reference/v8/options).
+
+## Duende IdentityServer Multi-Issuer
+
+<span data-shb-badge data-shb-badge-variant="default">Added in 8.0</span>
+
+The Multi-Issuer feature allows a single IdentityServer to respond with different `iss` claim values depending on the host that issued the request. 
+
+Imagine the IdentityServer instance is hosted over 3 different domains like `auth.dailyreader.example`, `auth.streamwave.example`, and `auth.podvault.example`. Users will be able to sign-in across all three domains with the same credentials, but the result token only works for the APIs accepting tokens from the target issuer. For example, if the backend API only allows tokens with the issuer `auth.dailyreader.example`, a user will not be able to use their token from `auth.streamwave.example` against it. Even though their credentials work across all three domains, the token is limited to the one issuer.
+
+If you set a static value for the `IssuerUri` property in [IdentityServer Options](/identityserver/reference/v8/options), the Multi-Issuer feature will not be enabled because the returned `iss` claim will always be the value you set.
+
+:::caution
+Multi-Issuer does not mean IdentityServer can self-host itself across different domains to separate data across different tenants.
+:::

--- a/astro/src/content/docs/identityserver/tokens/issuer.mdx
+++ b/astro/src/content/docs/identityserver/tokens/issuer.mdx
@@ -18,7 +18,7 @@ Duende IdentityServer can respond with different `iss` claim values depending on
 
 Imagine a single IdentityServer instance is hosted over 3 different domains like `auth.dailyreader.example`, `auth.streamwave.example`, and `auth.podvault.example`. If that instance of IdentityServer was developed to allow users to sign-in across all three domains with the same credentials, the result token still only works for the APIs accepting tokens from the target issuer. For example, if the backend API only allows tokens with the issuer `auth.dailyreader.example`, a user's token with `iss` claim `auth.streamwave.example` will not be accepted. Even though their credentials work across all three domains, the token is limited to the one issuer.
 
-If you set a static value for the `IssuerUri` property in [IdentityServer Options](/identityserver/reference/v8/options), the Multi-Issuer feature will not be enabled because the returned `iss` claim will always be the value you set.
+If you set a static value for the `IssuerUri` property in [IdentityServer Options](/identityserver/reference/v8/options), Multi-Issuer will not be enabled because the returned `iss` claim will always be the value you set.
 
 :::caution
 Multi-Issuer does not mean IdentityServer can self-host itself across different domains to separate data across different tenants. You must set up that infrastructure yourself.

--- a/astro/src/content/docs/identityserver/tokens/issuer.mdx
+++ b/astro/src/content/docs/identityserver/tokens/issuer.mdx
@@ -21,5 +21,5 @@ Imagine a single IdentityServer instance is hosted over 3 different domains like
 If you set a static value for the `IssuerUri` property in [IdentityServer Options](/identityserver/reference/v8/options), the Multi-Issuer feature will not be enabled because the returned `iss` claim will always be the value you set.
 
 :::caution
-Multi-Issuer does not mean IdentityServer can self-host itself across different domains to separate data across different tenants. You must setup that infrastructure yourself.
+Multi-Issuer does not mean IdentityServer can self-host itself across different domains to separate data across different tenants. You must set up that infrastructure yourself.
 :::

--- a/astro/src/content/docs/identityserver/tokens/issuer.mdx
+++ b/astro/src/content/docs/identityserver/tokens/issuer.mdx
@@ -18,7 +18,7 @@ Duende IdentityServer can respond with different `iss` claim values depending on
 
 Imagine a single IdentityServer instance is hosted over 3 different domains like `auth.dailyreader.example`, `auth.streamwave.example`, and `auth.podvault.example`. If that instance of IdentityServer was developed to allow users to sign-in across all three domains with the same credentials, the result token still only works for the APIs accepting tokens from the target issuer. For example, if the backend API only allows tokens with the issuer `auth.dailyreader.example`, a user's token with `iss` claim `auth.streamwave.example` will not be accepted. Even though their credentials work across all three domains, the token is limited to the one issuer.
 
-If you set a static value for the `IssuerUri` property in [IdentityServer Options](/identityserver/reference/v8/options), Multi-Issuer will not be enabled because the returned `iss` claim will always be the value you set.
+If you configure the `IssuerUri` property in [IdentityServer Options](/identityserver/reference/v8/options), Multi-Issuer will not be enabled: the returned `iss` claim will always contain the configured `IssuerUri` value.
 
 :::caution
 Multi-Issuer does not mean IdentityServer can self-host itself across different domains to separate data across different tenants. You must set up that infrastructure yourself.


### PR DESCRIPTION
- Added a new page for Multi-Issuer at path `/identityserver/tokens/issuer/`
- Changed the Multi-Issuer link at `/identityserver/` to go to the new page instead of the IdentityServer Options page

