### PR TITLE
Add IndexNow API Key to public folder

### DIFF
--- a/astro/public/f8830c36ec8046eaaeb9c4a87adb0720.txt
+++ b/astro/public/f8830c36ec8046eaaeb9c4a87adb0720.txt
@@ -1,0 +1,1 @@
+f8830c36ec8046eaaeb9c4a87adb0720


### PR DESCRIPTION

This pull request introduces the addition of the IndexNow API Key to the public folder, enabling improved compatibility and functionality for the IndexNow protocol.