### PR TITLE
Add preview Duende.Storage and Spaces documentation

### DIFF
--- a/astro/src/content/docs/identityserver/data/configuration.mdx
+++ b/astro/src/content/docs/identityserver/data/configuration.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configuration Data
 description: "Documentation about configuration data models and stores in Duende IdentityServer, including client, resource, and identity provider stores"
+date: 2026-09-01
 sidebar:
   order: 10
 redirect_from:
@@ -26,6 +27,10 @@ The stores used in Duende IdentityServer are:
 * [Resource store](/identityserver/reference/v8/stores/resource-store.md) for `IdentityResource`, `ApiResource`, and
   `ApiScope` data.
 * [Identity Provider store](/identityserver/reference/v8/stores/idp-store.md) for `IdentityProvider` data.
+
+Choose a provider to implement these interfaces. The [storage provider overview](/identityserver/data/providers/index.mdx)
+compares in-memory, Entity Framework Core, `Duende.Storage`, and custom implementations. The preview `Duende.Storage`
+provider also supplies [configuration administration APIs](/identityserver/data/providers/duende-storage/admin-apis.md).
 
 ## Registering Custom Stores
 

--- a/astro/src/content/docs/identityserver/data/index.mdx
+++ b/astro/src/content/docs/identityserver/data/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Data Stores and Persistence
 description: Overview of IdentityServer data stores types, including configuration and operational data, and their implementation options
+date: 2026-09-01
 sidebar:
   label: Overview
   order: 1
@@ -22,11 +23,12 @@ to access the data it needs at runtime when processing requests. You can impleme
 or choose one of the built-in providers.
 
 :::note
-Given that data stores abstract the details of the data stored, strictly speaking, IdentityServer does not know or
-understand where the data is actually being stored. As such, there is no built-in administrative tool to populate or manage this data.
+Store interfaces abstract where data is stored, so IdentityServer's protocol engine does not directly administer it.
+The preview [Duende.Storage provider](/identityserver/data/providers/duende-storage/index.mdx) includes configuration
+administration APIs that you can use to build a management experience.
 
-There are third-party options (both commercial and FOSS) that provide an administrative UI for managing the data when
-using the EntityFramework Core implementations. See [Admin UI](/identityserver/ui/admin.md) for details.
+Third-party options, both commercial and free and open source software (FOSS), provide administrative UIs for the Entity
+Framework Core implementations. See [Admin UI](/identityserver/ui/admin.md) for details.
 :::
 
 <CardGrid>
@@ -43,6 +45,6 @@ using the EntityFramework Core implementations. See [Admin UI](/identityserver/u
   <LinkCard
     href="/identityserver/data/providers/"
     title="Storage Providers"
-    description="Choose how and where your data is stored: Entity Framework Core, in-memory, or a custom implementation."
+    description="Choose how and where your data is stored: Duende.Storage, Entity Framework Core, in-memory, or a custom implementation."
   />
 </CardGrid>

--- a/astro/src/content/docs/identityserver/data/operational.md
+++ b/astro/src/content/docs/identityserver/data/operational.md
@@ -1,6 +1,7 @@
 ---
 title: Operational Data
 description: Documentation for managing dynamic operational data in IdentityServer including grants, keys, and server-side sessions
+date: 2026-09-01
 sidebar:
   order: 20
 redirect_from:
@@ -142,6 +143,9 @@ builder.Services.AddIdentityServer()
 ### EntityFramework Store Implementation
 
 An EntityFramework Core implementation of the server-side session store is included in the [Entity Framework Integration](/identityserver/data/providers/entityframework-core.md#operational-store) operational store.
+
+The preview [`Duende.Storage` operational provider](/identityserver/data/providers/duende-storage/operational-storage.md)
+also implements the server-side session store and the other operational stores.
 
 When using the EntityFramework Core operational store, it will be necessary to indicate that server-side sessions need to be used with the call to the `AddServerSideSessions` fluent API.
 For example:

--- a/astro/src/content/docs/identityserver/data/providers/duende-storage/_meta.yml
+++ b/astro/src/content/docs/identityserver/data/providers/duende-storage/_meta.yml
@@ -1,0 +1,3 @@
+label: "Duende.Storage"
+collapsed: false
+order: 30

--- a/astro/src/content/docs/identityserver/data/providers/duende-storage/admin-apis.md
+++ b/astro/src/content/docs/identityserver/data/providers/duende-storage/admin-apis.md
@@ -1,0 +1,226 @@
+---
+title: "Configuration Admin APIs"
+description: "Create and manage IdentityServer configuration with the preview Duende.Storage administration APIs"
+date: 2026-09-01
+sidebar:
+  label: "Admin APIs"
+  order: 30
+---
+
+:::caution[Preview documentation]
+This page describes preview packages and APIs that are subject to change. Start with the
+[Duende.Storage overview](/identityserver/data/providers/duende-storage/index.mdx) for the preview scope.
+:::
+
+[`AddConfigurationStorage`](/identityserver/data/providers/duende-storage/configuration-storage.md) registers
+administration services alongside the stores that IdentityServer uses at runtime. These are .NET service APIs, not
+preconfigured HTTP endpoints. You decide how to expose them through a protected administration application, command-line
+tool, or deployment process.
+
+Never expose an administration API without authentication and authorization. Keep it on a trusted network where possible,
+require a dedicated administrative policy, validate anti-forgery protections for browser clients, and audit changes.
+
+## Available Services
+
+| Service                     | Manages                                                    |
+| --------------------------- | ---------------------------------------------------------- |
+| `IClientAdmin`              | OpenID Connect and OAuth clients, including client secrets |
+| `IApiScopeAdmin`            | API scopes                                                 |
+| `IApiResourceAdmin`         | API resources, scope relationships, and API secrets        |
+| `IIdentityResourceAdmin`    | Identity resources                                         |
+| `IIdentityProviderAdmin`    | Dynamic identity providers                                 |
+| `ISamlServiceProviderAdmin` | SAML service providers                                     |
+
+Each service supports create, get, update, query, and delete operations. Resolve the service from a dependency injection
+scope, such as an authorized endpoint or a scoped application service.
+
+## Create Configuration
+
+The following examples show the minimum shape of each configuration type. Create referenced scopes before resources or
+clients that use them.
+
+### API Scope
+
+```csharp
+// ConfigurationAdmin.cs
+using Duende.IdentityServer.Admin;
+using Duende.IdentityServer.Admin.ApiScopes;
+
+static Task<SaveResult<Guid>> CreateApiScope(
+    IApiScopeAdmin admin,
+    CancellationToken ct) =>
+    admin.CreateAsync(
+        new ApiScopeConfiguration
+        {
+            Name = "inventory.read",
+            DisplayName = "Read inventory"
+        },
+        ct);
+```
+
+### API Resource
+
+```csharp
+// ConfigurationAdmin.cs
+using Duende.IdentityServer.Admin;
+using Duende.IdentityServer.Admin.ApiResources;
+
+static Task<SaveResult<Guid>> CreateApiResource(
+    IApiResourceAdmin admin,
+    CancellationToken ct) =>
+    admin.CreateAsync(
+        new ApiResourceConfiguration
+        {
+            Name = "inventory",
+            DisplayName = "Inventory API",
+            Scopes = ["inventory.read"]
+        },
+        ct);
+```
+
+### Identity Resource
+
+```csharp
+// ConfigurationAdmin.cs
+using Duende.IdentityServer.Admin;
+using Duende.IdentityServer.Admin.IdentityResources;
+
+static Task<SaveResult<Guid>> CreateIdentityResource(
+    IIdentityResourceAdmin admin,
+    CancellationToken ct) =>
+    admin.CreateAsync(
+        new IdentityResourceConfiguration
+        {
+            Name = "employee_profile",
+            DisplayName = "Employee profile",
+            UserClaims = ["department", "employee_id"]
+        },
+        ct);
+```
+
+### Client
+
+```csharp
+// ConfigurationAdmin.cs
+using Duende.IdentityServer.Admin;
+using Duende.IdentityServer.Admin.Clients;
+
+static Task<SaveResult<Guid>> CreateClient(
+    IClientAdmin admin,
+    CancellationToken ct) =>
+    admin.CreateAsync(
+        new CreateClient
+        {
+            ClientId = "inventory-worker",
+            ClientName = "Inventory worker",
+            AllowedGrantTypes = ["client_credentials"],
+            AllowedScopes = ["inventory.read"],
+            ClientSecrets =
+            [
+                new CreateClientSecret
+                {
+                    PlaintextValue = "replace-with-a-secret-from-a-secure-source"
+                }
+            ]
+        },
+        ct);
+```
+
+The API hashes plaintext client and API secret values before storage. Read secrets from a secret manager, never source
+control or application configuration committed with your code. Secret values are not returned by read operations.
+
+### Dynamic Identity Provider
+
+```csharp
+// ConfigurationAdmin.cs
+using Duende.IdentityServer.Admin;
+using Duende.IdentityServer.Admin.IdentityProviders;
+
+static Task<SaveResult<Guid>> CreateIdentityProvider(
+    IIdentityProviderAdmin admin,
+    CancellationToken ct) =>
+    admin.CreateAsync(
+        new IdentityProviderConfiguration
+        {
+            Scheme = "corporate-oidc",
+            DisplayName = "Corporate sign-in",
+            Type = "oidc",
+            Properties = new Dictionary<string, string>
+            {
+                ["Authority"] = "https://login.example.com",
+                ["ClientId"] = "identityserver"
+            }
+        },
+        ct);
+```
+
+Register the corresponding dynamic provider type and supply all protocol-specific properties it requires. IdentityServer
+validates the configuration before storing it.
+
+### SAML Service Provider
+
+```csharp
+// ConfigurationAdmin.cs
+using Duende.IdentityServer.Admin;
+using Duende.IdentityServer.Admin.SamlServiceProviders;
+using Duende.IdentityServer.Models;
+
+static Task<SaveResult<Guid>> CreateSamlServiceProvider(
+    ISamlServiceProviderAdmin admin,
+    CancellationToken ct) =>
+    admin.CreateAsync(
+        new SamlServiceProviderConfiguration
+        {
+            EntityId = "https://service-provider.example.com",
+            DisplayName = "Example service provider",
+            AssertionConsumerServiceUrls =
+            [
+                new SamlIndexedEndpointConfiguration
+                {
+                    Location = "https://service-provider.example.com/saml/acs",
+                    Binding = SamlBinding.HttpPost,
+                    Index = 0,
+                    IsDefault = true
+                }
+            ]
+        },
+        ct);
+```
+
+## Handle Results And Updates
+
+Create, update, and delete operations return `SaveResult<TId>`. Check `IsSuccess` before using `Id` or `Version`; failed
+results contain structured `Errors`. Get operations return `GetResult<T>`, whose `Found` property tells you whether `Item`
+and `Version` are available.
+
+Updates require the version returned by the preceding create or get operation:
+
+```csharp
+// ConfigurationAdmin.cs
+var scopeId = new Guid("0198f3a4-5760-7000-8000-000000000001");
+var current = await apiScopes.GetAsync(scopeId, ct);
+
+if (!current.Found)
+{
+    throw new InvalidOperationException("The API scope does not exist.");
+}
+
+current.Item.DisplayName = "Inventory read access";
+
+var updated = await apiScopes.UpdateAsync(
+    scopeId,
+    current.Item,
+    current.Version,
+    ct);
+
+if (!updated.IsSuccess)
+{
+    throw new InvalidOperationException(updated.Errors.ToString());
+}
+```
+
+This optimistic concurrency check prevents one administrator from silently overwriting another administrator's changes.
+Handle validation, duplicate-name, not-found, and version-conflict errors explicitly in your administration interface.
+
+For custom fields on clients and resources, configure
+[data extension schemas](/identityserver/data/providers/duende-storage/schemas.md).

--- a/astro/src/content/docs/identityserver/data/providers/duende-storage/configuration-storage.md
+++ b/astro/src/content/docs/identityserver/data/providers/duende-storage/configuration-storage.md
@@ -1,0 +1,99 @@
+---
+title: "Duende.Storage Configuration Storage"
+description: "Configure the preview Duende.Storage provider for IdentityServer clients, resources, and identity providers"
+date: 2026-09-01
+sidebar:
+  label: "Configuration Storage"
+  order: 10
+---
+
+:::caution[Preview documentation]
+This page describes preview packages and APIs that are subject to change. Start with the
+[Duende.Storage overview](/identityserver/data/providers/duende-storage/index.mdx) for the preview scope.
+:::
+
+Configuration storage persists the data that defines how IdentityServer behaves: clients, API scopes, API resources,
+identity resources, dynamic identity providers, Security Assertion Markup Language (SAML) service providers, and
+Cross-Origin Resource Sharing (CORS) origins.
+
+## Install The Packages
+
+Install the IdentityServer preview and one database provider. This example uses SQLite:
+
+```bash
+# Terminal
+dotnet add package Duende.IdentityServer --prerelease
+dotnet add package Duende.Storage.Sqlite --prerelease
+```
+
+The packages are available from the
+[Duende.IdentityServer](https://www.nuget.org/packages/Duende.IdentityServer) and
+[Duende.Storage.Sqlite](https://www.nuget.org/packages/Duende.Storage.Sqlite) NuGet Gallery pages.
+
+## Register The Provider And Stores
+
+Register one database provider before adding the IdentityServer storage adapters:
+
+```csharp
+// Program.cs
+using Duende.Storage.Internal;
+using Duende.Storage.Schema;
+using Duende.Storage.Sqlite;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddStorageInternal(storage =>
+    storage.AddSqliteStore(options =>
+        options.ConnectionString =
+            builder.Configuration.GetConnectionString("IdentityServer")
+            ?? throw new InvalidOperationException(
+                "IdentityServer connection string is missing.")));
+
+builder.Services
+    .AddIdentityServer()
+    .AddConfigurationStorage();
+
+var app = builder.Build();
+
+await app.Services
+    .GetRequiredService<IDatabaseSchema>()
+    .MigrateAsync(CancellationToken.None);
+
+app.UseIdentityServer();
+app.Run();
+```
+
+`AddStorageInternal` is the current preview bootstrap API. Its name and shape may change before general availability.
+Do not hide a missing connection string or continue startup after a migration failure.
+
+`AddConfigurationStorage` registers storage-backed implementations of:
+
+- `IClientStore`
+- `IResourceStore`
+- `IIdentityProviderStore`
+- `ISamlServiceProviderStore`
+- `ICorsPolicyService`
+
+It also registers the
+[configuration administration APIs](/identityserver/data/providers/duende-storage/admin-apis.md).
+
+`IDatabaseSchema.MigrateAsync` creates or upgrades the common Duende storage schema. In production, run migrations as a
+controlled deployment step so that multiple application instances do not attempt the same migration concurrently.
+
+## Other Database Providers
+
+Replace the SQLite package and `AddSqliteStore` call with the provider for your database:
+
+| Database   | Package                                                                                 | Registration         |
+| ---------- | --------------------------------------------------------------------------------------- | -------------------- |
+| SQL Server | [`Duende.Storage.MsSql`](https://www.nuget.org/packages/Duende.Storage.MsSql)           | `AddMsSqlStore`      |
+| PostgreSQL | [`Duende.Storage.PostgreSql`](https://www.nuget.org/packages/Duende.Storage.PostgreSql) | `AddPostgreSqlStore` |
+| Oracle     | [`Duende.Storage.Oracle`](https://www.nuget.org/packages/Duende.Storage.Oracle)         | `AddOracleStore`     |
+| SQLite     | [`Duende.Storage.Sqlite`](https://www.nuget.org/packages/Duende.Storage.Sqlite)         | `AddSqliteStore`     |
+
+SQL Server, PostgreSQL, and Oracle use their provider-native connection factory or data source registrations. Keep
+credentials outside source control and use your deployment platform's secret store.
+
+To persist runtime data as well, add
+[`AddOperationalStorage`](/identityserver/data/providers/duende-storage/operational-storage.md) to the same
+`IIdentityServerBuilder`.

--- a/astro/src/content/docs/identityserver/data/providers/duende-storage/index.mdx
+++ b/astro/src/content/docs/identityserver/data/providers/duende-storage/index.mdx
@@ -1,0 +1,72 @@
+---
+title: "Duende.Storage"
+description: "Overview of the preview Duende.Storage provider for IdentityServer configuration and operational data"
+date: 2026-09-01
+sidebar:
+  label: "Overview"
+  order: 1
+---
+
+import { Badge, CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+<Badge text="Preview" variant="caution" />
+
+:::caution[Preview documentation]
+`Duende.Storage` and the documentation in this section are previews. APIs, packages, database schemas, and behavior are
+subject to change before general availability.
+:::
+
+`Duende.Storage` is a relational persistence layer shared by Duende products. IdentityServer adapters connect its
+[configuration](/identityserver/data/configuration.mdx) and [operational](/identityserver/data/operational.md) store
+interfaces to the storage layer, so IdentityServer continues to use the same abstractions during protocol processing.
+
+## How It Works
+
+The provider has four parts:
+
+1. A database-specific package connects `Duende.Storage` to SQL Server, PostgreSQL, Oracle, or SQLite.
+2. The storage layer persists versioned data objects, alternate lookup keys, searchable fields, and expiration data.
+3. IdentityServer adapters implement its configuration and operational store interfaces.
+4. Optional administration APIs and schemas let your application manage and extend configuration data.
+
+Configuration and operational storage are independent. You can enable either one, both, or combine `Duende.Storage` with
+another provider. When both use `Duende.Storage`, they share the configured database provider and schema.
+
+## Why Use Duende.Storage?
+
+Choose `Duende.Storage` when you need one or more of these capabilities:
+
+* Configuration administration through supported service APIs, without writing directly to database tables.
+* Schema-validated custom properties on clients and resources.
+* Consistent querying and optimistic concurrency across supported databases.
+* Storage pools that isolate data for [Spaces](/identityserver/spaces/index.mdx).
+* A shared persistence model across Duende products.
+
+The [Entity Framework Core provider](/identityserver/data/providers/entityframework-core.md) remains a good choice when your
+application already uses EF Core and your team wants to manage `DbContext` types, mappings, and migrations directly.
+[In-memory stores](/identityserver/data/providers/in-memory.md) remain useful for development or deployment-controlled
+configuration. A [custom store](/identityserver/data/providers/custom.md) gives you complete control when neither built-in
+approach matches your requirements.
+
+<CardGrid>
+  <LinkCard
+    href="/identityserver/data/providers/duende-storage/configuration-storage/"
+    title="Configuration Storage"
+    description="Persist clients, resources, and identity providers."
+  />
+  <LinkCard
+    href="/identityserver/data/providers/duende-storage/operational-storage/"
+    title="Operational Storage"
+    description="Persist grants, device codes, sessions, signing keys, and runtime state."
+  />
+  <LinkCard
+    href="/identityserver/data/providers/duende-storage/admin-apis/"
+    title="Configuration Admin APIs"
+    description="Create and manage configuration through dependency-injected services."
+  />
+  <LinkCard
+    href="/identityserver/data/providers/duende-storage/schemas/"
+    title="Data Extension Schemas"
+    description="Add validated custom properties to supported configuration entities."
+  />
+</CardGrid>

--- a/astro/src/content/docs/identityserver/data/providers/duende-storage/operational-storage.md
+++ b/astro/src/content/docs/identityserver/data/providers/duende-storage/operational-storage.md
@@ -1,0 +1,74 @@
+---
+title: "Duende.Storage Operational Storage"
+description: "Configure the preview Duende.Storage provider for IdentityServer grants, sessions, keys, and runtime state"
+date: 2026-09-01
+sidebar:
+  label: "Operational Storage"
+  order: 20
+---
+
+:::caution[Preview documentation]
+This page describes preview packages and APIs that are subject to change. Start with the
+[Duende.Storage overview](/identityserver/data/providers/duende-storage/index.mdx) for the preview scope.
+:::
+
+Operational storage holds short-lived and security-sensitive state generated while IdentityServer processes protocol
+requests. This includes persisted grants, device codes, pushed authorization requests, server-side sessions, signing
+keys, and SAML request state.
+
+## Register Operational Storage
+
+First register a database provider as shown in
+[Configuration Storage](/identityserver/data/providers/duende-storage/configuration-storage.md#register-the-provider-and-stores).
+Then add the operational adapters:
+
+```csharp
+// Program.cs
+using Duende.IdentityServer.Configuration;
+
+builder.Services.Configure<StoragePurgeOptions>(options =>
+{
+    options.PurgeInterval = TimeSpan.FromMinutes(30);
+    options.BatchSize = 200;
+});
+
+builder.Services
+    .AddIdentityServer()
+    .AddOperationalStorage();
+```
+
+`AddOperationalStorage` registers implementations of:
+
+- `IPersistedGrantStore`
+- `IDeviceFlowStore`
+- `IPushedAuthorizationRequestStore`
+- `IServerSideSessionStore`
+- `ISigningKeyStore`
+- `ISamlSigninStateStore`
+- `ISamlLogoutSessionStore`
+
+Call [`AddServerSideSessions`](/identityserver/ui/server-side-sessions/index.md) separately when you want IdentityServer to
+use server-side sessions.
+
+The provider also adds a background purge service. Purging is enabled by default, runs hourly, deletes `100` expired
+entities per batch, and fuzzes its initial start time to reduce collisions between nodes. Configure `StoragePurgeOptions`
+to tune those values, or set `EnablePurge` to `false` when an external job owns cleanup.
+
+## Use Configuration And Operational Storage Together
+
+Both adapters can share one database provider:
+
+```csharp
+// Program.cs
+var identityServer = builder.Services
+    .AddIdentityServer()
+    .AddConfigurationStorage()
+    .AddOperationalStorage();
+```
+
+Run the `IDatabaseSchema` migration described in the
+[configuration setup](/identityserver/data/providers/duende-storage/configuration-storage.md#register-the-provider-and-stores)
+before the application starts serving requests.
+
+Operational records contain tokens, grants, session data, and signing material. Restrict database access, encrypt
+connections and backups, and avoid logging stored payloads or secrets.

--- a/astro/src/content/docs/identityserver/data/providers/duende-storage/schemas.md
+++ b/astro/src/content/docs/identityserver/data/providers/duende-storage/schemas.md
@@ -1,0 +1,114 @@
+---
+title: "Data Extension Schemas"
+description: "Add schema-validated custom properties to Duende.Storage-backed IdentityServer configuration"
+date: 2026-09-01
+sidebar:
+  label: "Schemas"
+  order: 40
+---
+
+:::caution[Preview documentation]
+This page describes preview packages and APIs that are subject to change. Start with the
+[Duende.Storage overview](/identityserver/data/providers/duende-storage/index.mdx) for the preview scope.
+:::
+
+Data extension schemas let you add typed properties to configuration entities without changing the Duende storage
+database schema. Values remain part of the entity, while schema metadata defines their type, validation, queryability, and
+display information.
+
+IdentityServer supports extensions on:
+
+- Clients
+- API resources
+- API scopes
+- Identity resources
+
+## In-Memory Or Storage-Backed Schemas
+
+| Schema Store   | Choose It When                                                                                                  |
+| -------------- | --------------------------------------------------------------------------------------------------------------- |
+| In-memory      | Schema definitions live with application code, change through deployments, and must be identical on every node. |
+| Storage-backed | An administration system must create or change schemas at runtime without redeploying IdentityServer.           |
+
+In-memory schemas are often the safer starting point. They keep schema changes in source control and release review, while
+configuration values can still be managed dynamically through the
+[admin APIs](/identityserver/data/providers/duende-storage/admin-apis.md).
+
+Storage-backed schemas register `ISchemaAdmin` as well as `ISchemaStore`. They are more dynamic, but your administration
+system must coordinate schema compatibility with all running application versions. Use
+`AddStorageDataExtensionSchemas()` when you intentionally need that model.
+
+## Define An In-Memory Schema
+
+Define typed attributes once and reuse those definitions when assigning values:
+
+```csharp
+// ClientDataExtensions.cs
+using Duende.IdentityServer.Stores.Storage;
+using Duende.Storage.EntityAttributeValue;
+
+public static class ClientDataExtensions
+{
+    public static readonly TypedAttributeDefinition<string> Department =
+        new(
+            AttributeCode.Create("department"),
+            new ScalarAttributeType(ScalarDataType.String));
+
+    public static readonly TypedAttributeDefinition<int> CostCenter =
+        new(
+            AttributeCode.Create("cost_center"),
+            new ScalarAttributeType(ScalarDataType.Integer));
+
+    public static readonly SchemaConfiguration Schema = new()
+    {
+        SchemaId = SchemaId.Client,
+        DisplayName = "Client extensions",
+        Description = "Organization data attached to clients.",
+        AttributeDefinitions = [Department, CostCenter]
+    };
+}
+```
+
+Register the schema when configuring IdentityServer:
+
+```csharp
+// Program.cs
+builder.Services
+    .AddIdentityServer()
+    .AddConfigurationStorage()
+    .AddInMemoryDataExtensionSchemas(
+        [ClientDataExtensions.Schema]);
+```
+
+`SchemaId.Client`, `SchemaId.ApiResource`, `SchemaId.ApiScope`, and `SchemaId.IdentityResource` select the entity type to
+extend. Only register one schema for each ID.
+
+## Set Extended Properties
+
+Use the same typed definitions to add values to an administration model:
+
+```csharp
+// ConfigurationAdmin.cs
+using Duende.IdentityServer.Admin.Clients;
+using Duende.Storage.EntityAttributeValue;
+
+var extensions = new AttributeValueCollection();
+extensions.Set(ClientDataExtensions.Department, "Sales");
+extensions.Set(ClientDataExtensions.CostCenter, 4100);
+
+var client = new CreateClient
+{
+    ClientId = "sales-dashboard",
+    AllowedGrantTypes = ["client_credentials"],
+    ExtendedProperties = extensions
+};
+
+var result = await clientAdmin.CreateAsync(client, ct);
+```
+
+The admin API rejects unknown properties, values of the wrong type, missing required properties, and duplicate values for
+attributes marked as unique. Set `IsQueryable` only for values that your administration experience must filter or sort;
+queryable fields require additional database indexing and storage.
+
+Treat schema changes like contract changes. Adding an optional property is usually compatible. Renaming or removing a
+property, changing its type, or making it required can invalidate existing entities and older application versions.

--- a/astro/src/content/docs/identityserver/data/providers/index.mdx
+++ b/astro/src/content/docs/identityserver/data/providers/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Storage Providers
 description: Overview of the available storage provider options for Duende IdentityServer configuration and operational data.
+date: 2026-09-01
 sidebar:
   label: Overview
   order: 1
@@ -22,8 +23,28 @@ Duende IdentityServer abstracts data access behind store interfaces. You choose 
     description="Keep all data in application memory. Ideal for development, testing, and simple scenarios where durability is not required."
   />
   <LinkCard
+    href="/identityserver/data/providers/duende-storage/"
+    title="Duende.Storage (Preview)"
+    description="Use Duende's portable storage layer, configuration administration APIs, extensible schemas, and Spaces support."
+  />
+  <LinkCard
     href="/identityserver/data/providers/custom/"
     title="Custom"
     description="Implement the store interfaces yourself to use any database, storage backend, or data access technology."
   />
 </CardGrid>
+
+Configuration and operational data have different lifecycles. You can choose one provider for both, or combine providers when
+your deployment needs different behavior for each kind of data.
+
+| Provider | How It Works | Choose It When |
+| --- | --- | --- |
+| [In-memory](/identityserver/data/providers/in-memory.md) | Keeps data in the IdentityServer process. | You are developing, testing, or can redeploy whenever configuration changes. Do not use it for production operational data. |
+| [Entity Framework Core](/identityserver/data/providers/entityframework-core.md) | Maps IdentityServer entities to relational tables through Entity Framework Core. | Your team already uses EF Core and wants direct control over its contexts, mappings, and migrations. |
+| [Duende.Storage](/identityserver/data/providers/duende-storage/index.mdx) | Stores versioned entities through a common relational storage layer and supplies administration APIs. | You need runtime configuration management, extensible configuration data, or [Spaces](/identityserver/spaces/index.mdx), without building every store yourself. |
+| [Custom](/identityserver/data/providers/custom.md) | Replaces IdentityServer store interfaces with your implementations. | You need a database or data-access pattern that the built-in providers do not support. |
+
+`Duende.Storage` was introduced to give Duende products a shared persistence model. It separates IdentityServer's store
+interfaces from database-specific implementations, supplies consistent querying and optimistic concurrency, and supports
+isolated storage pools. The existing providers remain supported and may be a better fit when you prefer their simpler or
+more direct model.

--- a/astro/src/content/docs/identityserver/fundamentals/key-management.md
+++ b/astro/src/content/docs/identityserver/fundamentals/key-management.md
@@ -1,7 +1,7 @@
 ---
 title: "Key Management"
 description: "Learn how to manage cryptographic keys for token signing in IdentityServer using automatic or static key management"
-date: 2020-09-10T08:22:12+02:00
+date: 2026-09-01
 sidebar:
   order: 50
 redirect_from:
@@ -121,13 +121,14 @@ var idsvrBuilder = builder.Services.AddIdentityServer(options =>
 Automatic Key Management stores keys through the abstraction of the
 [`ISigningKeyStore`](/identityserver/data/operational.md#keys). You can implement this
 extensibility point to customize the storage of your keys (perhaps using a key
-vault of some kind), or use one of the two implementations of the
+vault of some kind), or use one of the implementations of the
 `ISigningKeyStore` that we provide:
 
-- the default `FileSystemKeyStore`, which writes keys to the file system.
-- the [EntityFramework operational store](/identityserver/data/providers/entityframework-core.md#operational-store) which writes keys to a database
-  using
-  EntityFramework.
+* The default `FileSystemKeyStore`, which writes keys to the file system.
+* The [Entity Framework operational store](/identityserver/data/providers/entityframework-core.md#operational-store),
+  which writes keys to a database using Entity Framework Core.
+* The preview [`Duende.Storage` operational provider](/identityserver/data/providers/duende-storage/operational-storage.md),
+  which writes keys through the common Duende storage layer.
 
 The default `FileSystemKeyStore` writes keys to the `KeyPath` directory
 configured in your IdentityServer host, which defaults to the directory

--- a/astro/src/content/docs/identityserver/spaces/_meta.yml
+++ b/astro/src/content/docs/identityserver/spaces/_meta.yml
@@ -1,0 +1,3 @@
+label: "Spaces"
+collapsed: false
+order: 7.5

--- a/astro/src/content/docs/identityserver/spaces/getting-started.md
+++ b/astro/src/content/docs/identityserver/spaces/getting-started.md
@@ -1,0 +1,129 @@
+---
+title: "Getting Started With Spaces"
+description: "Configure Duende.MultiSpace, request resolution, and an initial IdentityServer space"
+date: 2026-09-01
+sidebar:
+  label: "Getting Started"
+  order: 10
+---
+
+Spaces require [`Duende.Storage`](/identityserver/data/providers/duende-storage/index.mdx) for their management data and
+isolated storage pools.
+
+## Install The Packages
+
+This example uses SQLite:
+
+```bash
+# Terminal
+dotnet add package Duende.IdentityServer --prerelease
+dotnet add package Duende.Storage.Sqlite --prerelease
+dotnet add package Duende.MultiSpace --prerelease
+```
+
+See the [Duende.MultiSpace](https://www.nuget.org/packages/Duende.MultiSpace) NuGet Gallery page for package versions.
+
+## Configure Services
+
+Register the database provider, Spaces, and the IdentityServer stores:
+
+```csharp
+// Program.cs
+using Duende.MultiSpace;
+using Duende.Storage.Internal;
+using Duende.Storage.Schema;
+using Duende.Storage.Sqlite;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddStorageInternal(storage =>
+    storage.AddSqliteStore(options =>
+        options.ConnectionString =
+            builder.Configuration.GetConnectionString("IdentityServer")
+            ?? throw new InvalidOperationException(
+                "IdentityServer connection string is missing.")));
+
+builder.Services.AddMultiSpace();
+builder.Services.Configure<MultiSpaceOptions>(options =>
+{
+    options.SpacePathPrefix = "/t";
+    options.FallbackToDefault = false;
+});
+
+builder.Services
+    .AddIdentityServer()
+    .AddConfigurationStorage()
+    .AddOperationalStorage();
+
+var app = builder.Build();
+
+await app.Services
+    .GetRequiredService<IDatabaseSchema>()
+    .MigrateAsync(CancellationToken.None);
+```
+
+`FallbackToDefault` is already `false`; setting it explicitly makes the intended isolation behavior visible during review.
+The current preview storage bootstrap API is named `AddStorageInternal` and may change before general availability.
+
+## Create A Space
+
+Use `ISpaceAdmin` from a trusted provisioning or administration path:
+
+```csharp
+// Program.cs
+var spaces = app.Services.GetRequiredService<ISpaceAdmin>();
+
+var result = await spaces.CreateAsync(
+    new CreateSpaceConfiguration
+    {
+        Name = "Acme",
+        MatchPatterns =
+        [
+            new SpaceMatchPattern
+            {
+                Origin = "https://login.example.com",
+                Path = "/acme"
+            }
+        ]
+    },
+    CancellationToken.None);
+
+if (!result.IsSuccess)
+{
+    throw new InvalidOperationException(
+        $"Could not create the Acme space: {result.Errors}");
+}
+```
+
+This pattern requires both the origin and path to match. A request to
+`https://login.example.com/t/acme/.well-known/openid-configuration` resolves to the Acme pool.
+
+In a production application, make provisioning idempotent by querying existing spaces before creating them. Do not run
+unconditional creation on every application instance.
+
+## Add The Middleware
+
+Space resolution must run before ASP.NET Core routing because path-based matches rewrite `PathBase` and `Path`:
+
+```csharp
+// Program.cs
+app.UseMultiSpaceResolution();
+app.UseRouting();
+
+app.UseIdentityServer();
+
+app.Run();
+```
+
+If another middleware reads tenant-specific data, place it after `UseMultiSpaceResolution`. You can inject
+`ISpaceContextAccessor` into scoped services and call `GetSpaceId()` after resolution.
+
+## Choose Match Patterns
+
+- Use origin matching when each space has a dedicated host name.
+- Use path matching when spaces share a host. The default `/t` prefix keeps space paths separate from ordinary routes.
+- Use both when a space must be constrained to a specific host and path.
+
+Origins must include the scheme and host, plus the port when it is not the scheme default. Configure forwarded headers
+correctly when a trusted reverse proxy terminates Transport Layer Security (TLS), so IdentityServer resolves the public
+origin rather than an internal proxy address.

--- a/astro/src/content/docs/identityserver/spaces/index.mdx
+++ b/astro/src/content/docs/identityserver/spaces/index.mdx
@@ -1,0 +1,69 @@
+---
+title: "IdentityServer Spaces"
+description: "Use Spaces to isolate IdentityServer configuration and operational data in one deployment"
+date: 2026-09-01
+sidebar:
+  label: "Overview"
+  order: 1
+---
+
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+A space is an isolated IdentityServer environment within one application deployment. Each space has its own configuration
+and operational data, while the application shares the same process, code, and database infrastructure.
+
+Use Spaces when you need to host multiple security domains without operating a separate IdentityServer deployment for
+each one. Examples include software-as-a-service tenants, regional environments, or independently administered business
+units.
+
+## Storage Isolation
+
+Spaces build on the pooled storage model in
+[`Duende.Storage`](/identityserver/data/providers/duende-storage/index.mdx). Each space maps to a storage pool. IdentityServer
+resolves the current space at the start of a request and routes all subsequent store operations to that pool.
+
+The management pool stores space definitions. Pool `0` is the default space, and each configured space normally receives
+a separate positive pool ID. Moving a space to another pool changes which data it sees, so treat pool assignments as
+security boundaries rather than display metadata.
+
+## Request Resolution
+
+A space can match an incoming request by:
+
+* Origin, such as `https://tenant.example.com`
+* Path segment, such as `/acme` under the default `/t` prefix
+* Both origin and path
+
+Origin claims take precedence so a path cannot route a request away from a space that owns the host. With the default
+prefix, a space whose path is `/acme` receives requests under `/t/acme`. Middleware moves `/t/acme` to `PathBase` before
+ASP.NET Core routing, leaving the remaining path for IdentityServer endpoints.
+
+Requests that explicitly use the space path prefix but do not match a space receive `404 Not Found`. By default, other
+unmatched requests also receive `404 Not Found`; you can opt into the default space with `FallbackToDefault`.
+
+:::caution
+Only enable `FallbackToDefault` when serving an unmatched host or path from the default space is an intentional part of
+your isolation model. A strict `404 Not Found` response is safer for multi-tenant deployments.
+:::
+
+## Operational Considerations
+
+Spaces isolate persisted data, but they do not automatically isolate every process-level dependency. Review signing
+credentials, ASP.NET Core Data Protection, external caches, telemetry, rate limits, and custom services to decide whether
+they also need space-aware configuration.
+
+Your administration system must authorize operators for the specific spaces they manage. Never trust a space identifier
+supplied by a client without allowing the resolution middleware to validate it against a configured match pattern.
+
+<CardGrid>
+  <LinkCard
+    href="/identityserver/spaces/getting-started/"
+    title="Getting Started"
+    description="Configure storage, add space resolution, and create an initial space."
+  />
+  <LinkCard
+    href="/identityserver/data/providers/duende-storage/"
+    title="Duende.Storage"
+    description="Understand the storage provider and its preview status."
+  />
+</CardGrid>

--- a/astro/src/content/docs/identityserver/ui/admin.md
+++ b/astro/src/content/docs/identityserver/ui/admin.md
@@ -1,7 +1,7 @@
 ---
 title: "IdentityServer Admin UI"
 description: "Documentation for implementing an administrative UI for IdentityServer."
-date: 2020-09-10T08:22:12+02:00
+date: 2026-09-01
 sidebar:
   label: Admin
   order: 5
@@ -31,6 +31,10 @@ A configuration and administration UI allows you to configure your production sy
 You may want to consider reducing the number of available options in this UI, to prevent accidental configuration errors.
 For example, you may want to limit the options to only those that are relevant to your production environment, and not support editing all the various protocol, client, and resource options.
 A limited subset of the available options may be enough.
+
+The preview [`Duende.Storage` configuration administration APIs](/identityserver/data/providers/duende-storage/admin-apis.md)
+provide create, read, update, query, and delete operations for clients, resources, and dynamic providers. You can use these
+service APIs behind your own authorized UI without writing directly to storage tables.
 
 :::tip[Duende IdentityServer AdminUI Templates]
 Creating custom, specialized admin UI functionality is demonstrated in the [Duende IdentityServer (`duende-is`) template](/identityserver/overview/packaging.mdx#duende-identityserver).

--- a/astro/src/content/docs/identityserver/ui/login/dynamicproviders.md
+++ b/astro/src/content/docs/identityserver/ui/login/dynamicproviders.md
@@ -1,7 +1,7 @@
 ---
 title: "Dynamic Providers"
 description: "Documentation for IdentityServer's Dynamic Identity Providers feature, which enables configuring external authentication providers from a store at runtime without performance penalties or application recompilation."
-date: 2026-05-28
+date: 2026-09-01
 sidebar:
   label: Dynamic Providers
   order: 65
@@ -38,10 +38,11 @@ You can also add [custom authentication handlers](#custom-authentication-handler
 ## Store And Configuration Data
 
 Dynamic identity providers require a store for the configuration data.
-There are two store implementations provided by Duende IdentityServer:
+Duende IdentityServer provides these store implementations:
 
 * An in-memory store
 * A store backed by a database (using [Entity Framework Core](/identityserver/data/providers/entityframework-core.md))
+* The preview [`Duende.Storage` configuration provider](/identityserver/data/providers/duende-storage/configuration-storage.md)
 
 You could also implement your own store based on the [`IIdentityProviderStore` interface](/identityserver/reference/v8/stores/idp-store.md).
 
@@ -52,8 +53,10 @@ If you use a custom store, there is an [extension method to enable caching](/ide
 If you use the EF stores, there is a general helper [to enable caching for all configuration data](/identityserver/data/providers/entityframework-core.md#enabling-caching-for-configuration-store).
 :::
 
-The identity provider store only provides an interface to query dynamic providers and does not provide any methods to add, update, or delete identity providers.
-For custom store implementations, this means you'll need to implement a mechanism for populating the store with identity providers.
+The identity provider store only provides an interface to query dynamic providers. Entity Framework Core and custom
+implementations need a separate mechanism for adding, updating, or deleting them. `Duende.Storage` includes an
+[`IIdentityProviderAdmin`](/identityserver/data/providers/duende-storage/admin-apis.md#dynamic-identity-provider)
+implementation for those operations.
 
 ## OIDC Providers
 

--- a/astro/src/content/docs/identityserver/ui/server-side-sessions/index.md
+++ b/astro/src/content/docs/identityserver/ui/server-side-sessions/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Overview"
 description: "An introduction to IdentityServer's server-side sessions feature, which stores authentication state on the server rather than in cookies for improved manageability and security."
+date: 2026-09-01
 sidebar:
   order: 1
 redirect_from:
@@ -51,8 +52,10 @@ builder.Services.AddIdentityServer()
 ```
 
 By default, the store for the server-side sessions will just be kept in-memory.
-For production scenarios you will want to configure a durable store either by using our [EntityFramework Core implementation](/identityserver/data/providers/entityframework-core.md#operational-store),
-or you can [implement the store yourself](/identityserver/reference/v8/stores/server-side-sessions.md).
+For production scenarios, configure a durable store by using the
+[Entity Framework Core implementation](/identityserver/data/providers/entityframework-core.md#operational-store), the
+preview [`Duende.Storage` operational provider](/identityserver/data/providers/duende-storage/operational-storage.md), or
+[your own implementation](/identityserver/reference/v8/stores/server-side-sessions.md).
 
 :::note
 Order is important in the ASP.NET Core service provider.
@@ -92,8 +95,10 @@ builder.Services.AddIdentityServer(options => {
 
 The [`IServerSideSessionStore`](/identityserver/reference/v8/stores/server-side-sessions.md) is the abstraction for storing the server-side session.
 
-An EntityFramework Core implementation is already provided as part of our [operational store](/identityserver/data/providers/entityframework-core.md#operational-store), but you can implement
-the [interface](/identityserver/reference/v8/stores/server-side-sessions.md) yourself for other backing implementations.
+Entity Framework Core and the preview
+[`Duende.Storage` operational provider](/identityserver/data/providers/duende-storage/operational-storage.md) include
+implementations. You can also implement the
+[`IServerSideSessionStore` interface](/identityserver/reference/v8/stores/server-side-sessions.md) for another backend.
 
 :::caution[Prefer `GetSessionsAsync` over `QuerySessionsAsync`]
 When listing sessions, prefer `GetSessionsAsync` over `QuerySessionsAsync`.


### PR DESCRIPTION
## Summary

- documents the preview `Duende.Storage` provider, including conceptual guidance and separate configuration and operational setup
- documents configuration administration APIs and in-memory data extension schemas
- adds a top-level IdentityServer Spaces overview and getting-started guide
- updates existing storage, administration, dynamic provider, session, and key-management pages with relevant cross-references

## Validation

- built the Astro site with Node.js 24
- confirmed all internal links are valid
- checked preview examples against `Duende.IdentityServer` 8.1.0-preview.2, `Duende.Storage` 2.0.0-preview.1, and `Duende.MultiSpace` 1.0.0-preview.1
- completed an adversarial review focused on API accuracy, preview labeling, secret handling, and space isolation