### PR TITLE
Add `alt` text to logo configuration

### DIFF
--- a/astro/astro.config.mjs
+++ b/astro/astro.config.mjs
@@ -199,6 +199,7 @@ export default defineConfig({
         },
       ],
       logo: {
+        alt: "Duende Software",
         light: "./src/assets/duende-logo.svg",
         dark: "./src/assets/duende-logo-dark.svg",
         replacesTitle: true,


### PR DESCRIPTION
This pull request adds descriptive `alt` text to the logo configuration in the Astro project to improve accessibility.